### PR TITLE
Allows users to hide their username when reporting a raid. [NEEDS TEST]

### DIFF
--- a/app/constants.js
+++ b/app/constants.js
@@ -12,6 +12,11 @@ const GymParameter = {
   FAVORITE: 'favorite'
 };
 
+const PrivacyOpts = {
+  ANONYMOUS: 1,
+  VISIBLE: 0
+};
+
 const PartyStatus = {
   NOT_INTERESTED: -1,
   INTERESTED: 0,
@@ -46,4 +51,4 @@ const TimeParameter = {
   END: 'end'
 };
 
-module.exports = {CommandGroup, GymParameter, PartyStatus, PartyType, Team, TimeMode, TimeParameter};
+module.exports = {CommandGroup, GymParameter, PartyStatus, PartyType, Team, TimeMode, TimeParameter, PrivacyOpts};

--- a/app/db/20181027-privacy.js
+++ b/app/db/20181027-privacy.js
@@ -1,0 +1,19 @@
+const {PrivacyOpts} = require('../constants');
+
+exports.up = function (knex, Promise) {
+  return Promise.all([
+    knex.schema.table('User', table => {
+      table.integer('raidPrivacy')
+        .notNullable()
+        .defaultTo(PrivacyOpts.VISIBLE);
+    })
+  ])
+};
+
+exports.down = function (knex, Promise) {
+  return Promise.all([
+    knex.schema.table('User', table => {
+      table.dropColumn('raidPrivacy');
+    })
+  ])
+};

--- a/app/privacy.js
+++ b/app/privacy.js
@@ -1,0 +1,68 @@
+"use strict";
+
+const log = require('loglevel').getLogger('Status'),
+  DB = require('./db'),
+  lunr = require('lunr'),
+  {PrivacyOpts} = require('./constants'),
+  Search = require('./search');
+
+class Privacy extends Search {
+  constructor() {
+    super();
+  }
+
+  async buildIndex() {
+    log.info('Indexing statuses...');
+
+    this.index = lunr(function () {
+      this.ref('privacy');
+      this.field('name');
+
+      // remove stop word filter
+      this.pipeline.remove(lunr.stopWordFilter);
+
+      // Anonymous Raid Reports aliases
+      this.add({'privacy': PrivacyOpts.ANONYMOUS, name: 'hidden'});
+      this.add({'privacy': PrivacyOpts.ANONYMOUS, name: 'anonymous'});
+
+      // Shown Raid Reports aliases
+      this.add({'status': PrivacyOpts.VISIBLE, 'name': 'visible'});
+      this.add({'status': PrivacyOpts.VISIBLE, 'name': 'non-anonymous'});
+    });
+
+    log.info('Indexing statuses complete');
+  }
+
+  search(term) {
+    return Search.singleTermSearch(term.toLowerCase(), this.index, ['name']);
+  }
+
+  // get user's privacy state for reporting raids; if they're not in the table at all,
+  // assume they're visible
+  async getPrivacyStatus(memberId) {
+    const result = await DB.DB('User')
+      .where('userSnowflake', memberId)
+      .pluck('raidPrivacy')
+      .first();
+
+    return !!result ?
+      result.status :
+      PrivacyOpts.VISIBLE;
+  }
+
+  // set user's automatic status for raids to value passed in
+  setPrivacyStatus(member, privacy) {
+    return DB.insertIfAbsent('User', Object.assign({},
+      {
+        userSnowflake: member.user.id
+      }))
+      .then(userId => DB.DB('User')
+        .where('id', userId)
+        .update({
+          raidPrivacy: privacy
+        }))
+      .catch(err => log.error(err));
+  }
+}
+
+module.exports = new Privacy();

--- a/app/privacy.js
+++ b/app/privacy.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const log = require('loglevel').getLogger('Status'),
+const log = require('loglevel').getLogger('Privacy'),
   DB = require('./db'),
   lunr = require('lunr'),
   {PrivacyOpts} = require('./constants'),

--- a/app/raid.js
+++ b/app/raid.js
@@ -36,6 +36,7 @@ class Raid extends Party {
     if (!raidExists) {
       // add some extra raid data to remember
       raid.createdById = memberPrivacy ? -1 : memberId;
+      raid.originallyCreatedBy = memberId;
       raid.isExclusive = !!pokemon.exclusive;
       raid.sourceChannelId = sourceChannelId;
       raid.creationTime = moment().valueOf();

--- a/app/raid.js
+++ b/app/raid.js
@@ -854,6 +854,7 @@ class Raid extends Party {
 
   toJSON() {
     return Object.assign(super.toJSON(), {
+      originallyCreatedBy: this.originallyCreatedBy,
       isExclusive: this.isExclusive,
       lastPossibleTime: this.lastPossibleTime,
       timeWarn: this.timeWarn,

--- a/app/raid.js
+++ b/app/raid.js
@@ -796,7 +796,7 @@ class Raid extends Party {
                 .then(message => message.delete({timeout: settings.messageCleanupDelayStatus}))
                 .then(async result => {
                   this.messages.splice(this.messages.indexOf(currentAnnouncementMessage), 1);
-                  await this.psersist();
+                  await this.persist();
                 })
                 .catch(err => log.error(err));
             } else {

--- a/commands/raids/report-privacy.js
+++ b/commands/raids/report-privacy.js
@@ -1,13 +1,13 @@
 "use strict";
 
-const log = require('loglevel').getLogger('AutoCommand'),
+const log = require('loglevel').getLogger('PrivacyCommand'),
   Commando = require('discord.js-commando'),
   {CommandGroup} = require('../../app/constants'),
   Helper = require('../../app/helper'),
   settings = require('../../data/settings'),
   Privacy = require('../../app/privacy');
 
-class AutoCommand extends Commando.Command {
+class PrivacyCommand extends Commando.Command {
   constructor(client) {
     super(client, {
       name: 'auto',
@@ -46,4 +46,4 @@ class AutoCommand extends Commando.Command {
   }
 }
 
-module.exports = AutoCommand;
+module.exports = PrivacyCommand;

--- a/commands/raids/report-privacy.js
+++ b/commands/raids/report-privacy.js
@@ -1,0 +1,49 @@
+"use strict";
+
+const log = require('loglevel').getLogger('AutoCommand'),
+  Commando = require('discord.js-commando'),
+  {CommandGroup} = require('../../app/constants'),
+  Helper = require('../../app/helper'),
+  settings = require('../../data/settings'),
+  Privacy = require('../../app/privacy');
+
+class AutoCommand extends Commando.Command {
+  constructor(client) {
+    super(client, {
+      name: 'auto',
+      group: CommandGroup.RAID_CRUD,
+      memberName: 'privacy',
+      aliases: ['report-privacy'],
+      description: 'Changes the visibility of your username when reporting a raid.\n',
+      details: 'Use this command to change the visibility of your name when reporting a new raid.',
+      examples: ['\t!privacy hidden', '\t!privacy shown'],
+      args: [
+        {
+          key: 'privacy',
+          label: 'privacy',
+          prompt: 'What what level of privacy do you want when reporting raids (visible, hidden)?\n',
+          type: 'privacy'
+        }
+      ],
+      argsPromptLimit: 3,
+      guildOnly: true
+    });
+
+    client.dispatcher.addInhibitor(message => {
+      if (!!message.command && message.command.name === 'privacy' && !Helper.isBotChannel(message)) {
+        return ['invalid-channel', message.reply(Helper.getText('auto-status.warning', message))];
+      }
+      return false;
+    });
+  }
+
+  async run(message, args) {
+    const privacyChoice = args['privacy'];
+
+    Privacy.setPrivacyStatus(message.member, privacyChoice)
+      .then(result => message.react(Helper.getEmoji(settings.emoji.thumbsUp) || '👍'))
+      .catch(err => log.error(err));
+  }
+}
+
+module.exports = AutoCommand;

--- a/index.js
+++ b/index.js
@@ -119,6 +119,7 @@ Client.registry.registerCommands([
   require('./commands/raids/set-location'),
 
   require('./commands/raids/auto-status'),
+  require('./commands/raids/report-privacy'),
 
   require('./commands/raids/train'),
 


### PR DESCRIPTION
Would add a `!privacy` command to allow users to anonymously report raids. Looking for both feedback and potential testing.

This would implement #12 through a new option specific to this (so they can report and auto-not interest, but still do !interest).