### PR TITLE
New Raid Boss - Quick Add Command

### DIFF
--- a/app/db/20181127-pokemon.js
+++ b/app/db/20181127-pokemon.js
@@ -5,9 +5,11 @@ exports.up = function (knex, Promise) {
         .primary();
 
       table.integer('tier')
-        .unsigned();
+        .unsigned()
+        .defaultTo(0);
       
       table.boolean('exclusive')
+           .defaultTo(false);
     })
   ])
 };

--- a/app/db/20181127-pokemon.js
+++ b/app/db/20181127-pokemon.js
@@ -6,6 +6,8 @@ exports.up = function (knex, Promise) {
 
       table.integer('tier')
         .unsigned();
+      
+      table.boolean('exclusive')
     })
   ])
 };

--- a/app/db/20181127-pokemon.js
+++ b/app/db/20181127-pokemon.js
@@ -1,8 +1,11 @@
 exports.up = function (knex, Promise) {
   return Promise.all([
     knex.schema.createTable('Pokemon', table => {
-      table.string('name', 100)
+      table.increments('id')
         .primary();
+      
+      table.string('name', 100)
+        .unique();
 
       table.integer('tier')
         .unsigned()

--- a/app/db/20181127-pokemon.js
+++ b/app/db/20181127-pokemon.js
@@ -1,0 +1,17 @@
+exports.up = function (knex, Promise) {
+  return Promise.all([
+    knex.schema.createTable('Pokemon', table => {
+      table.string('name', 100)
+        .primary();
+
+      table.integer('tier')
+        .unsigned();
+    })
+  ])
+};
+
+exports.down = function (knex, Promise) {
+  return Promise.all([
+    knex.schema.dropTable('Pokemon')
+  ])
+};

--- a/app/helper.js
+++ b/app/helper.js
@@ -179,6 +179,21 @@ class Helper {
     }
     return isModOrAdmin || this.client.isOwner(message.author);
   }
+  
+  isBotManagement(message) {
+    let isModOrAdmin = this.isManagement(message);
+    let isBotMod = false; 
+    if (message.channel.type !== 'dm') {
+      const botModRole = this.getRole(message.guild, 'bot-developer'),
+            botRoleId = botModRole ?
+              botModRole.id : 
+              -1;
+      
+      isBotMod = message.member.roles.has(botRoleId);
+    }
+    
+    return isModOrAdmin || isBotMod || this.client.isOwner(message.author);
+  }
 
   isBotChannel(message) {
     if (message.channel.type === 'dm') {

--- a/app/helper.js
+++ b/app/helper.js
@@ -184,7 +184,7 @@ class Helper {
     let isModOrAdmin = this.isManagement(message);
     let isBotMod = false; 
     if (message.channel.type !== 'dm') {
-      const botModRole = this.getRole(message.guild, 'bot-developer'),
+      const botModRole = this.getRole(message.guild, 'bot developer'),
             botRoleId = botModRole ?
               botModRole.id : 
               -1;

--- a/app/pokemon.js
+++ b/app/pokemon.js
@@ -212,7 +212,11 @@ class Pokemon extends Search {
       updateObject.exclusive = true; 
     }
     
-    if (['1', '2', '3', '4', '5'].indexOf(tier) !== -1) {
+    if (tier === 'unset-ex') {
+      updateObject.exclusive = false;
+    }
+    
+    if (['0', '1', '2', '3', '4', '5'].indexOf(tier) !== -1) {
       updateObject.tier = tier;
     }
     

--- a/app/pokemon.js
+++ b/app/pokemon.js
@@ -88,20 +88,29 @@ class Pokemon extends Search {
       mergedPokemon.forEach(pokemon => {
         const pokemonDocument = Object.create(null);
 
-        pokemonDocument['object'] = JSON.stringify(pokemon);
-        pokemonDocument['name'] = pokemon.name;
-        pokemonDocument['nickname'] = (pokemon.nickname) ? pokemon.nickname.join(' ') : '';
-        pokemonDocument['tier'] = pokemon.tier;
-        pokemonDocument['bossCP'] = pokemon.bossCP;
-
         let updatedTier = await DB.DB('Pokemon')
                                   .where('name', pokemon.name)
                                   .pluck('tier')
                                   .first();
         
+        let updatedExclusive = await DB.DB('Pokemon')
+                                       .where('name', pokemon.name)
+                                       .pluck('exclusive')
+                                       .first();
+        
         if (!!updatedTier) {
-          pokemonDocument.tier = updatedTier;
+          pokemon.tier = updatedTier;
         }
+        
+        if (!!updatedExclusive) {
+          pokemon.exclusive = updatedExclusive;
+        }
+        
+        pokemonDocument['object'] = JSON.stringify(pokemon);
+        pokemonDocument['name'] = pokemon.name;
+        pokemonDocument['nickname'] = (pokemon.nickname) ? pokemon.nickname.join(' ') : '';
+        pokemonDocument['tier'] = pokemon.tier;
+        pokemonDocument['bossCP'] = pokemon.bossCP;
         
         this.add(pokemonDocument);
       }, this);

--- a/app/pokemon.js
+++ b/app/pokemon.js
@@ -205,6 +205,31 @@ class Pokemon extends Search {
     return results;
   }
 
+  addRaidBoss(pokemon, tier) {
+    let updateObject = {};
+    
+    if (tier === 'ex') {
+      updateObject.exclusive = true; 
+    }
+    
+    if (['1', '2', '3', '4', '5'].indexOf(tier) !== -1) {
+      updateObject.tier = tier;
+    }
+    
+    if (Object.keys(updateObject).length === 0) {
+      return;
+    }
+    
+    return DB.insertIfAbsent('Pokemon', Object.assign({},
+      {
+        name: pokemon
+      }))
+      .then(pokemonId => DB.DB('Pokemon')
+        .where('id', pokemonId)
+        .update(updateObject))
+      .catch(err => log.error(err));
+  }
+  
   static calculateWeaknesses(pokemonTypes) {
     if (!pokemonTypes) {
       return [];

--- a/app/pokemon.js
+++ b/app/pokemon.js
@@ -2,6 +2,7 @@
 
 const log = require('loglevel').getLogger('PokemonSearch'),
   lunr = require('lunr'),
+  DB = require('./db'),
   GameMaster = require('pokemongo-game-master'),
   removeDiacritics = require('diacritics').remove,
   Search = require('./search'),
@@ -93,6 +94,15 @@ class Pokemon extends Search {
         pokemonDocument['tier'] = pokemon.tier;
         pokemonDocument['bossCP'] = pokemon.bossCP;
 
+        let updatedTier = await DB.DB('Pokemon')
+                                  .where('name', pokemon.name)
+                                  .pluck('tier')
+                                  .first();
+        
+        if (!!updatedTier) {
+          pokemonDocument.tier = updatedTier;
+        }
+        
         this.add(pokemonDocument);
       }, this);
     });

--- a/commands/admin/raid-boss.js
+++ b/commands/admin/raid-boss.js
@@ -1,0 +1,1 @@
+// add management command for !raid-boss <pokemon> <tier>

--- a/commands/admin/raid-boss.js
+++ b/commands/admin/raid-boss.js
@@ -15,7 +15,7 @@ class AddRaidBossCommand extends Commando.Command {
       memberName: 'raid-boss',
       description: 'Adds a new raid boss.',
       examples: ['\t!raid-boss magnemite 1'],
-      arguments: [
+      args: [
         {
           key: 'pokemon',
           prompt: 'What pokémon are you adding?\nExample: `lugia`\n',
@@ -43,13 +43,13 @@ class AddRaidBossCommand extends Commando.Command {
 
   async run(message, args) {
     const pokemon = args['pokemon'],
-          tier = args['tier'];
-    
-    Pokemon.addRaidBoss(pokemon, tier)
-           .then(result => {
-              message.react(Helper.getEmoji(settings.emoji.thumbsUp) || '👍');
-              Pokemon.buildIndex();
-           }).catch(err => log.error(err));
+      tier = args['tier'];
+
+    Pokemon.addRaidBoss(pokemon.name, tier)
+      .then(result => {
+        message.react(Helper.getEmoji(settings.emoji.thumbsUp) || '👍');
+        Pokemon.buildIndex();
+      }).catch(err => log.error(err));
   }
 }
 

--- a/commands/admin/raid-boss.js
+++ b/commands/admin/raid-boss.js
@@ -1,1 +1,49 @@
-// add management command for !raid-boss <pokemon> <tier>
+"use strict";
+
+const log = require('loglevel').getLogger('AddRaidBossCommand'),
+  Commando = require('discord.js-commando'),
+  {CommandGroup} = require('../../app/constants'),
+  Helper = require('../../app/helper'),
+  Role = require('../../app/role'),
+  settings = require('../../data/settings');
+
+class AddRaidBossCommand extends Commando.Command {
+  constructor(client) {
+    super(client, {
+      name: 'raid-boss',
+      group: CommandGroup.ADMIN,
+      memberName: 'raid-boss',
+      description: 'Adds a new raid boss.',
+      examples: ['\t!raid-boss magnemite 1'],
+      arguments: [
+        {
+          key: 'pokemon',
+          prompt: 'What pokémon are you adding?\nExample: `lugia`\n',
+          type: 'pokemon'
+        },
+        {
+          key: 'tier',
+          prompt: 'What tier is this pokémon? (`1`, `2`, `3`, `4`, `5`, `ex`)',
+          type: 'string'
+        }
+      ],
+      guildOnly: true
+    });
+
+    client.dispatcher.addInhibitor(message => {
+      if (!!message.command && message.command.name === 'raid-boss') {
+        if (!Helper.isBotManagement(message)) {
+          return ['unauthorized', message.reply('You are not authorized to use this command.')];
+        }
+      }
+
+      return false;
+    });
+  }
+
+  async run(message, args) {
+    // add to db.
+  }
+}
+
+module.exports = AddRaidBossCommand;

--- a/commands/admin/raid-boss.js
+++ b/commands/admin/raid-boss.js
@@ -4,7 +4,7 @@ const log = require('loglevel').getLogger('AddRaidBossCommand'),
   Commando = require('discord.js-commando'),
   {CommandGroup} = require('../../app/constants'),
   Helper = require('../../app/helper'),
-  Pokemon = requier ('../../app/pokemon'),
+  Pokemon = require('../../app/pokemon'),
   settings = require('../../data/settings');
 
 class AddRaidBossCommand extends Commando.Command {

--- a/commands/admin/raid-boss.js
+++ b/commands/admin/raid-boss.js
@@ -4,7 +4,7 @@ const log = require('loglevel').getLogger('AddRaidBossCommand'),
   Commando = require('discord.js-commando'),
   {CommandGroup} = require('../../app/constants'),
   Helper = require('../../app/helper'),
-  Role = require('../../app/role'),
+  Pokemon = requier ('../../app/pokemon'),
   settings = require('../../data/settings');
 
 class AddRaidBossCommand extends Commando.Command {
@@ -42,7 +42,12 @@ class AddRaidBossCommand extends Commando.Command {
   }
 
   async run(message, args) {
-    // add to db.
+    const pokemon = args['pokemon'],
+          tier = args['tier'];
+    
+    Pokemon.addRaidBoss(pokemon, tier)
+           .then(result => message.react(Helper.getEmoji(settings.emoji.thumbsUp) || '👍'))
+           .catch(err => log.error(err));
   }
 }
 

--- a/commands/admin/raid-boss.js
+++ b/commands/admin/raid-boss.js
@@ -46,8 +46,10 @@ class AddRaidBossCommand extends Commando.Command {
           tier = args['tier'];
     
     Pokemon.addRaidBoss(pokemon, tier)
-           .then(result => message.react(Helper.getEmoji(settings.emoji.thumbsUp) || '👍'))
-           .catch(err => log.error(err));
+           .then(result => {
+              message.react(Helper.getEmoji(settings.emoji.thumbsUp) || '👍');
+              Pokemon.buildIndex();
+           }).catch(err => log.error(err));
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -125,7 +125,8 @@ Client.registry.registerCommands([
 
   require('./commands/raids/submit-request'),
 
-  require('./commands/util/help')
+  require('./commands/util/help'),
+  require('./commands/admin/raid-boss')
 ]);
 
 if (privateSettings.regionMapLink !== '') {

--- a/types/pokemon.js
+++ b/types/pokemon.js
@@ -27,7 +27,7 @@ class PokemonType extends Commando.ArgumentType {
     const validPokemon = pokemon
       .find(pokemon => pokemon.exclusive || pokemon.tier);
 
-    if (!validPokemon) {
+    if (!validPokemon && message.command.name !== 'raid-boss') {
       const name = pokemon[0].name ?
         `"${pokemon[0].name.charAt(0).toUpperCase()}${pokemon[0].name.slice(1)}"` :
         'Pokémon';
@@ -49,8 +49,14 @@ class PokemonType extends Commando.ArgumentType {
       .map(term => term.match(/(?:<:)?([\w*]+)(?::[0-9]+>)?/)[1])
       .map(term => term.toLowerCase());
 
-    const pokemon = Pokemon.search(terms)
-      .find(pokemon => pokemon.exclusive || pokemon.tier);
+    let pokemon;
+
+    if (message.command.name !== 'raid-boss') {
+      pokemon = Pokemon.search(terms)
+        .find(pokemon => pokemon.exclusive || pokemon.tier);
+    } else {
+      pokemon = Pokemon.search(terms)[0];
+    }
 
     message.isExclusive = !!pokemon.exclusive;
 


### PR DESCRIPTION
As it stands, this PR provides the ability to quickly add raid bosses on the fly for those random, unannounced additions or changes. It is suggested to still keep `data/pokemon.json` updated.

Features:
- New `!raid-boss` command
- Limit command to bot developers, admins, moderators, and owner.
- Adds data to database table
- Merges database table data with data from the `data/pokemon.json` when indexing data
- Rebuild the index when the command is run