### PR TITLE
Raid Updates

### DIFF
--- a/app/db/20181221-autoset.js
+++ b/app/db/20181221-autoset.js
@@ -1,0 +1,20 @@
+exports.up = function (knex, Promise) {
+  return Promise.all([
+    knex.schema.createTable('AutosetPokemon', table => {
+      table.increments('id')
+        .primary();
+
+      table.string('name', 100)
+        .unique();
+
+      table.integer('tier')
+        .unsigned();
+    })
+  ])
+};
+
+exports.down = function (knex, Promise) {
+  return Promise.all([
+    knex.schema.dropTable('AutosetPokemon')
+  ])
+};

--- a/app/party-manager.js
+++ b/app/party-manager.js
@@ -30,14 +30,14 @@ class PartyManager {
       Object.entries(this.parties)
         .filter(([channelId, party]) => party.type === PartyType.RAID)
         .forEach(async ([channelId, party]) => {
-          console.log(party.hatchTime, now, lastIntervalTime, now > party.hatchTime, party.hatchTime > lastIntervalTime)
           if ((party.hatchTime && now > party.hatchTime && party.hatchTime > lastIntervalTime) ||
             nowDay !== lastIntervalDay) {
             party.refreshStatusMessages()
               .catch(err => log.error(err));
           }
 
-          if (now > party.hatchTime && party.hatchTime > lastIntervalRunTime) {
+          if ((now > party.hatchTime && party.hatchTime > lastIntervalRunTime)
+              || (now > party.endTime && party.endTime > lastIntervalRunTime)) {
             const newChannelName = party.generateChannelName();
 
             await this.getChannel(party.channelId)

--- a/app/pokemon.js
+++ b/app/pokemon.js
@@ -7,6 +7,7 @@ const log = require('loglevel').getLogger('PokemonSearch'),
   removeDiacritics = require('diacritics').remove,
   Search = require('./search'),
   privateSettings = require('../data/private-settings'),
+  settings = require('../data/settings'),
   types = require('../data/types'),
   weather = require('../data/weather');
 
@@ -52,7 +53,14 @@ class Pokemon extends Search {
           })),
       updatedPokemon = await DB.DB('Pokemon').select(),
       mergedPokemon = pokemonMetadata
-        .map(poke => Object.assign({}, poke, pokemon.find(p => p.name === poke.name)));
+        .map(poke => {
+          if (settings.databaseRaids) {
+            delete poke.tier;
+            delete poke.exclusive;
+          }
+
+          return Object.assign({}, poke, pokemon.find(p => p.name === poke.name))
+        });
 
     updatedPokemon.forEach(poke => {
       let pokeDataIndex = mergedPokemon.findIndex(p => poke.name === p.name);

--- a/app/pokemon.js
+++ b/app/pokemon.js
@@ -55,8 +55,15 @@ class Pokemon extends Search {
       mergedPokemon = pokemonMetadata
         .map(poke => {
           if (settings.databaseRaids) {
-            delete poke.tier;
-            delete poke.exclusive;
+            if (poke.tier) {
+              poke.backupTier = poke.tier;
+              delete poke.tier;
+            }
+
+            if (poke.exclusive) {
+              poke.backupExclusive = poke.exclusive;
+              delete poke.exclusive;
+            }
           }
 
           return Object.assign({}, poke, pokemon.find(p => p.name === poke.name))
@@ -214,6 +221,7 @@ class Pokemon extends Search {
     let updateObject = {};
 
     if (tier === 'ex') {
+      updateObject.tier = 5;
       updateObject.exclusive = true;
     }
 
@@ -224,6 +232,10 @@ class Pokemon extends Search {
     if (['0', '1', '2', '3', '4', '5'].indexOf(tier) !== -1) {
       updateObject.tier = tier;
     }
+
+    // if (Object.keys(updateObject).length === 0) {
+    //   console.log(pokemon, updateObject);
+    // }
 
     return DB.insertIfAbsent('Pokemon', Object.assign({},
       {

--- a/app/pokemon.js
+++ b/app/pokemon.js
@@ -237,10 +237,6 @@ class Pokemon extends Search {
       updateObject.tier = tier;
     }
 
-    // if (Object.keys(updateObject).length === 0) {
-    //   console.log(pokemon, updateObject);
-    // }
-
     return DB.insertIfAbsent('Pokemon', Object.assign({},
       {
         name: pokemon

--- a/app/pokemon.js
+++ b/app/pokemon.js
@@ -92,6 +92,7 @@ class Pokemon extends Search {
           alternateForm.formId :
           '00';
 
+      poke.formName = poke.name;
       poke.name = poke.overrideName ?
         poke.overrideName :
         poke.name;

--- a/app/raid.js
+++ b/app/raid.js
@@ -7,6 +7,7 @@ const log = require('loglevel').getLogger('Raid'),
   {PartyStatus, PartyType} = require('./constants'),
   Discord = require('discord.js'),
   Helper = require('./helper'),
+  Pokemon = require('./pokemon'),
   Party = require('./party'),
   Status = require('./status'),
   Privacy = require('./privacy'),
@@ -34,6 +35,14 @@ class Raid extends Party {
       memberPrivacy = await Privacy.getPrivacyStatus(memberId);
 
     if (!raidExists) {
+      if (pokemon.name === undefined) {
+        let defaultBoss = await Pokemon.getDefaultTierBoss(pokemon.tier);
+
+        if (defaultBoss !== null) {
+          pokemon = defaultBoss;
+        }
+      }
+
       // add some extra raid data to remember
       raid.createdById = memberPrivacy ?
         -1 :

--- a/app/raid.js
+++ b/app/raid.js
@@ -40,6 +40,7 @@ class Raid extends Party {
 
         if (defaultBoss !== null) {
           pokemon = defaultBoss;
+          raid.defaulted = true;
         }
       }
 
@@ -293,6 +294,16 @@ class Raid extends Party {
         .catch(err => log.error(err));
     }
 
+    const newChannelName = this.generateChannelName();
+
+    await PartyManager.getChannel(this.channelId)
+      .then(channelResult => {
+        if (channelResult.ok) {
+          return channelResult.channel.setName(newChannelName);
+        }
+      })
+      .catch(err => log.error(err));
+
     await this.persist();
 
     return {party: this};
@@ -359,6 +370,16 @@ class Raid extends Party {
         })
         .catch(err => log.error(err));
     }
+
+    const newChannelName = this.generateChannelName();
+
+    await PartyManager.getChannel(this.channelId)
+      .then(channelResult => {
+        if (channelResult.ok) {
+          return channelResult.channel.setName(newChannelName);
+        }
+      })
+      .catch(err => log.error(err));
 
     await this.persist();
 
@@ -845,13 +866,7 @@ class Raid extends Party {
     const nonCharCleaner = new RegExp(/[^\w]/, 'g'),
       pokemonName = (this.isExclusive ?
         'ex raid' :
-        !!this.pokemon.name ?
-          this.pokemon.name :
-          `tier ${this.pokemon.tier}`)
-        .replace(nonCharCleaner, ' ')
-        .split(' ')
-        .filter(token => token.length > 0)
-        .join('-'),
+        this.generatePokemonName(this.pokemon)),
       gym = Gym.getGym(this.gymId),
       gymName = (!!gym.nickname ?
         removeDiacritics(gym.nickname) :
@@ -863,6 +878,31 @@ class Raid extends Party {
         .join('-');
 
     return pokemonName + '-' + gymName;
+  }
+
+  generatePokemonName(pokemon) {
+    const nonCharCleaner = new RegExp(/[^\w]/, 'g');
+    let type = '',
+      now = moment(),
+      hatchTime = moment(this.hatchTime),
+      endTime = moment(this.endTime);
+
+    if (this.hatchTime === '' || now < hatchTime || hatchTime.isSame(now)) {
+      type = 'tier ' + pokemon.tier;
+    } else if (now >= endTime && pokemon.name === undefined) {
+      type = 'expired ' + pokemon.tier;
+    } else if (now >= endTime && pokemon.name !== undefined) {
+      type = 'expired ' + pokemon.name;
+    } else if (now >= hatchTime && pokemon.name === undefined) {
+      type = 'boss ' + pokemon.tier;
+    } else if (now >= hatchTime && pokemon.name !== undefined) {
+      type = pokemon.name;
+    }
+
+    return type.replace(nonCharCleaner, ' ')
+      .split(' ')
+      .filter(token => token.length > 0)
+      .join('-');
   }
 
   toJSON() {

--- a/app/raid.js
+++ b/app/raid.js
@@ -36,7 +36,7 @@ class Raid extends Party {
 
     if (!raidExists) {
       if (pokemon.name === undefined) {
-        let defaultBoss = await Pokemon.getDefaultTierBoss(pokemon.tier);
+        let defaultBoss = await Pokemon.getDefaultTierBoss(!!pokemon.exclusive ? 'ex' : pokemon.tier);
 
         if (defaultBoss !== null) {
           pokemon = defaultBoss;

--- a/app/raid.js
+++ b/app/raid.js
@@ -888,7 +888,7 @@ class Raid extends Party {
       endTime = moment(this.endTime);
 
     if (this.hatchTime === '' || now < hatchTime || hatchTime.isSame(now)) {
-      type = 'tier ' + pokemon.tier;
+      type = 'egg ' + pokemon.tier;
     } else if (now >= endTime && pokemon.name === undefined) {
       type = 'expired ' + pokemon.tier;
     } else if (now >= endTime && pokemon.name !== undefined) {

--- a/app/role.js
+++ b/app/role.js
@@ -211,7 +211,7 @@ class Role {
 
           resolve();
         } else {
-          reject({error: `Role "**${roleOrAlias}**" was not found.  Use \`${guild.client.commandPrefix}iam\` to see a list of self-assignable roles.`});
+          reject({error: `Role "**${roleOrAlias}**" was not found.  Use \`${guild.client.commandPrefix}iam\` to see a list of self-assignable roles. If you are attempting to reduce notifications, please see  \`${guild.client.commandPrefix}help\` for use of the \`${guild.client.commandPrefix}unwant\` and \`${guild.client.commandPrefix}untarget\` commands.`});
         }
       } else {
         roles = await this.roleExists(guild, roleOrAlias, true);

--- a/commands/admin/autoset.js
+++ b/commands/admin/autoset.js
@@ -31,7 +31,7 @@ class AutosetCommand extends Commando.Command {
     });
 
     client.dispatcher.addInhibitor(message => {
-      if (!!message.command && message.command.name === 'raid-boss') {
+      if (!!message.command && message.command.name === 'auto-set') {
         if (!Helper.isBotManagement(message)) {
           return ['unauthorized', message.reply('You are not authorized to use this command.')];
         }

--- a/commands/admin/autoset.js
+++ b/commands/admin/autoset.js
@@ -13,7 +13,7 @@ class AutosetCommand extends Commando.Command {
       name: 'auto-set',
       group: CommandGroup.ADMIN,
       memberName: 'auto-set',
-      description: 'Adds a new raid boss.',
+      description: 'Sets the default boss for a tier to be automatically set when reported.',
       examples: ['\t!auto-set magnemite 1'],
       args: [
         {

--- a/commands/admin/autoset.js
+++ b/commands/admin/autoset.js
@@ -1,0 +1,55 @@
+"use strict";
+
+const log = require('loglevel').getLogger('AutosetCommand'),
+  Commando = require('discord.js-commando'),
+  {CommandGroup} = require('../../app/constants'),
+  Helper = require('../../app/helper'),
+  Pokemon = require('../../app/pokemon'),
+  settings = require('../../data/settings');
+
+class AutosetCommand extends Commando.Command {
+  constructor(client) {
+    super(client, {
+      name: 'auto-set',
+      group: CommandGroup.ADMIN,
+      memberName: 'auto-set',
+      description: 'Adds a new raid boss.',
+      examples: ['\t!auto-set magnemite 1'],
+      args: [
+        {
+          key: 'pokemon',
+          prompt: 'What pokémon are you defaulting a tier to?\nExample: `lugia`\n',
+          type: 'pokemon'
+        },
+        {
+          key: 'tier',
+          prompt: 'What tier are you defaulting? (`1`, `2`, `3`, `4`, `5`, `ex`)',
+          type: 'string'
+        }
+      ],
+      guildOnly: true
+    });
+
+    client.dispatcher.addInhibitor(message => {
+      if (!!message.command && message.command.name === 'raid-boss') {
+        if (!Helper.isBotManagement(message)) {
+          return ['unauthorized', message.reply('You are not authorized to use this command.')];
+        }
+      }
+
+      return false;
+    });
+  }
+
+  async run(message, args) {
+    const pokemon = args['pokemon'],
+      tier = args['tier'];
+
+    Pokemon.setDefaultTierBoss(pokemon.name, tier)
+      .then(result => {
+        message.react(Helper.getEmoji(settings.emoji.thumbsUp) || '👍');
+      }).catch(err => log.error(err));
+  }
+}
+
+module.exports = AutosetCommand;

--- a/commands/admin/autoset.js
+++ b/commands/admin/autoset.js
@@ -45,7 +45,7 @@ class AutosetCommand extends Commando.Command {
     const pokemon = args['pokemon'],
       tier = args['tier'];
 
-    Pokemon.setDefaultTierBoss(pokemon.name, tier)
+    Pokemon.setDefaultTierBoss(pokemon.name || tier, tier)
       .then(result => {
         message.react(Helper.getEmoji(settings.emoji.thumbsUp) || '👍');
       }).catch(err => log.error(err));

--- a/commands/admin/autoset.js
+++ b/commands/admin/autoset.js
@@ -42,8 +42,12 @@ class AutosetCommand extends Commando.Command {
   }
 
   async run(message, args) {
-    const pokemon = args['pokemon'],
+    let pokemon = args['pokemon'],
       tier = args['tier'];
+
+    if (tier === 'ex') {
+      tier = 6;
+    }
 
     Pokemon.setDefaultTierBoss(pokemon.name || tier, tier)
       .then(result => {

--- a/commands/admin/populate-raid-bosses.js
+++ b/commands/admin/populate-raid-bosses.js
@@ -1,0 +1,60 @@
+"use strict";
+
+const log = require('loglevel').getLogger('PopulateRaidBossesCommand'),
+  Commando = require('discord.js-commando'),
+  {CommandGroup} = require('../../app/constants'),
+  Helper = require('../../app/helper'),
+  Pokemon = require('../../app/pokemon'),
+  settings = require('../../data/settings');
+
+class PopulateRaidBossesCommand extends Commando.Command {
+  constructor(client) {
+    super(client, {
+      name: 'populate-raid-bosses',
+      group: CommandGroup.ADMIN,
+      memberName: 'populate-raid-bosses',
+      description: 'Populates the database with all the pre-defined raid bosses.',
+      examples: ['\t!populate-raid-boss'],
+      args: [],
+      guildOnly: true
+    });
+
+    client.dispatcher.addInhibitor(message => {
+      if (!!message.command && message.command.name === 'populate-raid-bosses') {
+        if (!Helper.isBotManagement(message)) {
+          return ['unauthorized', message.reply('You are not authorized to use this command.')];
+        }
+      }
+
+      return false;
+    });
+  }
+
+  async run(message, args) {
+    const pokemonMetadata = require('../data/pokemon');
+
+    pokemonMetadata.forEach(pokemon => {
+      if (pokemon.exclusive) {
+        Pokemon.addRaidBoss(pokemon.name, 'ex')
+          .then(result => {
+            Pokemon.addRaidBoss(pokemon.name, pokemon.tier)
+              .then(result => {
+                console.log('Added ' + pokemon.name);
+              }).catch(err => log.error(err));
+          }).catch(err => log.error(err));
+      } else if (pokemon.tier) {
+        Pokemon.addRaidBoss(pokemon.name, pokemon.tier)
+          .then(result => {
+            console.log('Added ' + pokemon.name);
+          }).catch(err => log.error(err));
+      }
+    });
+
+    setTimeout(() => {
+      Pokemon.buildIndex();
+      message.react(Helper.getEmoji(settings.emoji.thumbsUp) || '👍');
+    }, 1000); // wait a second to populate the index to allow DB calls to fully finish since we're out of the asyncronous aspect.
+  }
+}
+
+module.exports = PopulateRaidBossesCommand;

--- a/commands/admin/populate-raid-bosses.js
+++ b/commands/admin/populate-raid-bosses.js
@@ -31,25 +31,23 @@ class PopulateRaidBossesCommand extends Commando.Command {
 
   async run(message, args) {
     const pokemonMetadata = require('../../data/pokemon');
-
+    let promises = [];
+    let names = [];
     pokemonMetadata.forEach(pokemon => {
       if (pokemon.backupExclusive) {
-        Pokemon.addRaidBoss(pokemon.name || 'ex', 'ex')
-          .then(result => {
-            console.log('Added ' + pokemon.name);
-          }).catch(err => log.error(err));
+        names.push(pokemon.name || 'ex');
+        promises.push(Pokemon.addRaidBoss(pokemon.name || 'ex', 'ex'));
       } else if (pokemon.backupTier) {
-        Pokemon.addRaidBoss(pokemon.name || pokemon.backupTier + '', pokemon.backupTier + '')
-          .then(result => {
-            console.log('Added ' + pokemon.name);
-          }).catch(err => log.error(err));
+        names.push(pokemon.name || pokemon.backupTier + '');
+        promises.push(Pokemon.addRaidBoss(pokemon.name || pokemon.backupTier + '', pokemon.backupTier + ''));
       }
     });
 
-    setTimeout(() => {
+    Promise.all(promises).then(result => {
       Pokemon.buildIndex();
       message.react(Helper.getEmoji(settings.emoji.thumbsUp) || '👍');
-    }, 1000); // wait a second to populate the index to allow DB calls to fully finish since we're out of the asyncronous aspect.
+      log.debug('Added ' + names.join(', '));
+    }).catch(err => log.error(err));
   }
 }
 

--- a/commands/admin/populate-raid-bosses.js
+++ b/commands/admin/populate-raid-bosses.js
@@ -33,14 +33,13 @@ class PopulateRaidBossesCommand extends Commando.Command {
     const pokemonMetadata = require('../../data/pokemon');
 
     pokemonMetadata.forEach(pokemon => {
-      console.log(pokemon);
       if (pokemon.backupExclusive) {
-        Pokemon.addRaidBoss(pokemon.name, 'ex')
+        Pokemon.addRaidBoss(pokemon.name || 'ex', 'ex')
           .then(result => {
             console.log('Added ' + pokemon.name);
           }).catch(err => log.error(err));
       } else if (pokemon.backupTier) {
-        Pokemon.addRaidBoss(pokemon.name, pokemon.backupTier + '')
+        Pokemon.addRaidBoss(pokemon.name || pokemon.backupTier + '', pokemon.backupTier + '')
           .then(result => {
             console.log('Added ' + pokemon.name);
           }).catch(err => log.error(err));

--- a/commands/admin/populate-raid-bosses.js
+++ b/commands/admin/populate-raid-bosses.js
@@ -14,8 +14,7 @@ class PopulateRaidBossesCommand extends Commando.Command {
       group: CommandGroup.ADMIN,
       memberName: 'populate-raid-bosses',
       description: 'Populates the database with all the pre-defined raid bosses.',
-      examples: ['\t!populate-raid-boss'],
-      args: [],
+      examples: ['\t!populate-raid-bosses'],
       guildOnly: true
     });
 
@@ -31,19 +30,17 @@ class PopulateRaidBossesCommand extends Commando.Command {
   }
 
   async run(message, args) {
-    const pokemonMetadata = require('../data/pokemon');
+    const pokemonMetadata = require('../../data/pokemon');
 
     pokemonMetadata.forEach(pokemon => {
-      if (pokemon.exclusive) {
+      console.log(pokemon);
+      if (pokemon.backupExclusive) {
         Pokemon.addRaidBoss(pokemon.name, 'ex')
           .then(result => {
-            Pokemon.addRaidBoss(pokemon.name, pokemon.tier)
-              .then(result => {
-                console.log('Added ' + pokemon.name);
-              }).catch(err => log.error(err));
+            console.log('Added ' + pokemon.name);
           }).catch(err => log.error(err));
-      } else if (pokemon.tier) {
-        Pokemon.addRaidBoss(pokemon.name, pokemon.tier)
+      } else if (pokemon.backupTier) {
+        Pokemon.addRaidBoss(pokemon.name, pokemon.backupTier + '')
           .then(result => {
             console.log('Added ' + pokemon.name);
           }).catch(err => log.error(err));

--- a/commands/admin/raid-boss.js
+++ b/commands/admin/raid-boss.js
@@ -45,7 +45,7 @@ class AddRaidBossCommand extends Commando.Command {
     const pokemon = args['pokemon'],
       tier = args['tier'];
 
-    Pokemon.addRaidBoss(pokemon.name, tier)
+    Pokemon.addRaidBoss(pokemon.formName, tier)
       .then(result => {
         message.react(Helper.getEmoji(settings.emoji.thumbsUp) || '👍');
         Pokemon.buildIndex();

--- a/commands/raids/raid.js
+++ b/commands/raids/raid.js
@@ -135,7 +135,9 @@ class RaidCommand extends Commando.Command {
               message.pokemon = raid.pokemon;
               message.isExclusive = raid.isExclusive;
 
-              if (raid.pokemon.name) {
+              let collectEndTime = raid.defaulted ? false : true;
+
+              if (raid.pokemon.name && collectEndTime) {
                 return this.endTimeCollector.obtain(message);
               } else {
                 return this.hatchTimeCollector.obtain(message);
@@ -143,9 +145,10 @@ class RaidCommand extends Commando.Command {
             })
             .then(async collectionResult => {
               Utility.cleanCollector(collectionResult);
+              let collectEndTime = raid.defaulted ? false : true;
 
               if (!collectionResult.cancelled) {
-                if (raid.pokemon.name) {
+                if (raid.pokemon.name && collectEndTime) {
                   await raid.setEndTime(collectionResult.values[TimeParameter.END]);
                 } else {
                   await raid.setHatchTime(collectionResult.values[TimeParameter.HATCH]);

--- a/commands/util/boss-tier.js
+++ b/commands/util/boss-tier.js
@@ -34,7 +34,9 @@ class BossTierCommand extends Commando.Command {
 
     message.react(Helper.getEmoji(settings.emoji.thumbsUp) || '👍')
       .then(result => {
-        let name = pokemon.name.split('');
+        console.log(pokemon);
+
+        let name = (pokemon.name || pokemon.tier + '').split('');
         name[0] = name[0].toUpperCase();
         name = name.join('');
         let tier = ' tier ' + pokemon.tier + '';

--- a/commands/util/boss-tier.js
+++ b/commands/util/boss-tier.js
@@ -38,16 +38,14 @@ class BossTierCommand extends Commando.Command {
         name[0] = name[0].toUpperCase();
         name = name.join('');
         let tier = ' tier ' + pokemon.tier + '';
-        if (pokemon.isExclusive) {
+        if (pokemon.exclusive) {
           tier = 'n exclusive';
         }
-        Helper.client.get(message.channel).send(name + ' is a' + tier + ' raid boss.');
+        message.channel.send(name + ' is a' + tier + ' raid boss.');
 
         return true;
       })
       .catch(err => log.error(err));
-
-    raid.refreshStatusMessages();
   }
 }
 

--- a/commands/util/boss-tier.js
+++ b/commands/util/boss-tier.js
@@ -1,0 +1,54 @@
+"use strict";
+
+const log = require('loglevel').getLogger('BossTierCommand'),
+  Commando = require('discord.js-commando'),
+  {CommandGroup, PartyType} = require('../../app/constants'),
+  Helper = require('../../app/helper'),
+  PartyManager = require('../../app/party-manager'),
+  settings = require('../../data/settings');
+
+class BossTierCommand extends Commando.Command {
+  constructor(client) {
+    super(client, {
+      name: 'boss-tier',
+      group: CommandGroup.UTIL,
+      memberName: 'boss-tier',
+      aliases: ['bosstier', 'boss-level'],
+      description: 'Changes the pokémon for an existing raid, usually to specify the actual raid boss for a now-hatched egg.',
+      details: 'Use this command to set the pokémon of a raid.',
+      examples: ['\t!boss-tier deoxys', '\t!boss-level mawile'],
+      args: [
+        {
+          key: 'pokemon',
+          prompt: 'What pokémon are you attempting to look up?\nExample: `lugia`\n',
+          type: 'pokemon',
+        }
+      ],
+      argsPromptLimit: 3,
+      guildOnly: true
+    });
+  }
+
+  async run(message, args) {
+    const pokemon = args['pokemon'];
+
+    message.react(Helper.getEmoji(settings.emoji.thumbsUp) || '👍')
+      .then(result => {
+        let name = pokemon.name.split('');
+        name[0] = name[0].toUpperCase();
+        name = name.join('');
+        let tier = ' tier ' + pokemon.tier + '';
+        if (pokemon.isExclusive) {
+          tier = 'n exclusive';
+        }
+        Helper.client.get(message.channel).send(name + ' is a' + tier + ' raid boss.');
+
+        return true;
+      })
+      .catch(err => log.error(err));
+
+    raid.refreshStatusMessages();
+  }
+}
+
+module.exports = BossTierCommand;

--- a/commands/util/boss-tier.js
+++ b/commands/util/boss-tier.js
@@ -27,6 +27,13 @@ class BossTierCommand extends Commando.Command {
       argsPromptLimit: 3,
       guildOnly: true
     });
+
+    client.dispatcher.addInhibitor(message => {
+      if (!!message.command && message.command.name === 'boss-tier' && !Helper.isBotChannel(message)) {
+        return ['invalid-channel', message.reply(Helper.getText('bosstier.warning', message))];
+      }
+      return false;
+    });
   }
 
   async run(message, args) {

--- a/commands/util/boss-tier.js
+++ b/commands/util/boss-tier.js
@@ -14,8 +14,8 @@ class BossTierCommand extends Commando.Command {
       group: CommandGroup.UTIL,
       memberName: 'boss-tier',
       aliases: ['bosstier', 'boss-level'],
-      description: 'Changes the pokémon for an existing raid, usually to specify the actual raid boss for a now-hatched egg.',
-      details: 'Use this command to set the pokémon of a raid.',
+      description: 'Looks up the tier for a particular pokémon.',
+      details: 'Use this command to look up the tier for a specific pokémon.',
       examples: ['\t!boss-tier deoxys', '\t!boss-level mawile'],
       args: [
         {

--- a/commands/util/boss-tier.js
+++ b/commands/util/boss-tier.js
@@ -13,7 +13,7 @@ class BossTierCommand extends Commando.Command {
       name: 'boss-tier',
       group: CommandGroup.UTIL,
       memberName: 'boss-tier',
-      aliases: ['bosstier', 'boss-level'],
+      aliases: ['boss-level'],
       description: 'Looks up the tier for a particular pokémon.',
       details: 'Use this command to look up the tier for a specific pokémon.',
       examples: ['\t!boss-tier deoxys', '\t!boss-level mawile'],

--- a/data/pokemon.json
+++ b/data/pokemon.json
@@ -498,7 +498,7 @@
       "exegg",
       "alex"
     ],
-    "tier": 4
+    "tier": 2
   },
   {
     "name": "cubone"

--- a/data/settings.json
+++ b/data/settings.json
@@ -12,6 +12,7 @@
   "messageCleanupDelaySuccess": 5000,
   "messageCleanupDelayError": 30000,
   "messageCleanupDelayStatus": 60000,
+  "databaseRaids": true,
   "emoji": {
     "thumbsUp": "pinethumbsup",
     "thumbsDown": "pinethumbsdown"

--- a/data/text.json
+++ b/data/text.json
@@ -8,6 +8,9 @@
   "iamnot": {
     "warning": "Unassign roles in ${bot-channel}!"
   },
+  "bosstier": {
+    "warning": "Check boss tiers in ${bot-channel}!"
+  },
   "favorites": {
     "warning": "Use the `!targets` command in ${bot-channel} to view current notifications for gyms."
   },

--- a/index.js
+++ b/index.js
@@ -128,7 +128,8 @@ Client.registry.registerCommands([
   require('./commands/util/help'),
   require('./commands/admin/raid-boss'),
   require('./commands/admin/populate-raid-bosses'),
-  require('./commands/util/boss-tier')
+  require('./commands/util/boss-tier'),
+  require('./commands/admin/autoset')
 ]);
 
 if (privateSettings.regionMapLink !== '') {

--- a/index.js
+++ b/index.js
@@ -126,7 +126,8 @@ Client.registry.registerCommands([
   require('./commands/raids/submit-request'),
 
   require('./commands/util/help'),
-  require('./commands/admin/raid-boss')
+  require('./commands/admin/raid-boss'),
+  require('./commands/admin/populate-raid-bosses')
 ]);
 
 if (privateSettings.regionMapLink !== '') {

--- a/index.js
+++ b/index.js
@@ -127,7 +127,8 @@ Client.registry.registerCommands([
 
   require('./commands/util/help'),
   require('./commands/admin/raid-boss'),
-  require('./commands/admin/populate-raid-bosses')
+  require('./commands/admin/populate-raid-bosses'),
+  require('./commands/util/boss-tier')
 ]);
 
 if (privateSettings.regionMapLink !== '') {

--- a/types/pokemon.js
+++ b/types/pokemon.js
@@ -34,8 +34,12 @@ class PokemonType extends Commando.ArgumentType {
         `"${pokemon[0].name.charAt(0).toUpperCase()}${pokemon[0].name.slice(1)}"` :
         'Pokémon';
 
-      let errorMessage = `${name} is not a valid raid boss.  Please try your search again, entering the text you want to search for.`;
-      if (!!arg) {
+      let errorMessage = `${name} is not a valid raid boss.`;
+
+      if (message.command && message.command.name !== 'boss-tier') {
+        errorMessage += '  Please try your search again, entering the text you want to search for.';
+      }
+      if (!!arg && (message.command && message.command.name !== 'boss-tier')) {
         errorMessage += `\n\n${arg.prompt}`;
       }
 


### PR DESCRIPTION
This PR does a few various things:

- Adds a new `!boss-tier` command to find out what level raid boss something is.
- Adds a new setting to run raid bosses strictly via the database
- Adds a new `!populate-raid-bosses` command that does an initial populate of the raid boss database.
- Adds a new `!auto-set` command that allows you to specify the default raid boss for a tier and sets it every time a raid is reported for that tier.
- Create a new channel name structure based on hatch/end time of a raid.
- Only show the raid boss once it's been hatched in the channel name
- Automatically update channel name based on actions (setting hatch/end time) and during routine clean up based on hatch and end time.
- Update error information to add some QOL clarifications.
- Fix `!raid-boss` logic
- Set Alolan Exeggutor to a Tier 2 boss