### PR TITLE
Add Shiny Pokemon indicator.

### DIFF
--- a/app/db/20190105-shiny.js
+++ b/app/db/20190105-shiny.js
@@ -1,5 +1,3 @@
-const {PrivacyOpts} = require('../constants');
-
 exports.up = function (knex, Promise) {
   return Promise.all([
     knex.schema.table('Pokemon', table => {

--- a/app/db/20190105-shiny.js
+++ b/app/db/20190105-shiny.js
@@ -1,0 +1,18 @@
+const {PrivacyOpts} = require('../constants');
+
+exports.up = function (knex, Promise) {
+  return Promise.all([
+    knex.schema.table('Pokemon', table => {
+      table.boolean('shiny')
+        .defaultTo(false);
+    })
+  ])
+};
+
+exports.down = function (knex, Promise) {
+  return Promise.all([
+    knex.schema.table('Pokemon', table => {
+      table.dropColumn('shiny');
+    })
+  ])
+};

--- a/app/pokemon.js
+++ b/app/pokemon.js
@@ -87,6 +87,10 @@ class Pokemon extends Search {
         if (!!poke.exclusive) {
           mergedPokemon[pokeDataIndex].exclusive = !!poke.exclusive;
         }
+
+        if (!!poke.shiny) {
+          mergedPokemon[pokeDataIndex].shiny = !!poke.shiny;
+        }
       }
     });
 
@@ -225,7 +229,20 @@ class Pokemon extends Search {
     return results;
   }
 
-  addRaidBoss(pokemon, tier) {
+  markShiny(pokemon) {
+    const updateObject = { shiny: true };
+
+    return DB.insertIfAbsent('Pokemon', Object.assign({},
+      {
+        name: pokemon
+      }))
+      .then(pokemonId => DB.DB('Pokemon')
+        .where('id', pokemonId)
+        .update(updateObject))
+      .catch(err => log.error(err));
+  }
+
+  addRaidBoss(pokemon, tier, shiny) {
     let updateObject = {};
 
     if (tier === 'ex') {
@@ -241,6 +258,10 @@ class Pokemon extends Search {
 
     if (['0', '1', '2', '3', '4', '5'].indexOf(tier) !== -1) {
       updateObject.tier = tier;
+    }
+
+    if (shiny) {
+      updateObject.shiny = shiny;
     }
 
     return DB.insertIfAbsent('Pokemon', Object.assign({},

--- a/app/pokemon.js
+++ b/app/pokemon.js
@@ -229,8 +229,8 @@ class Pokemon extends Search {
     return results;
   }
 
-  markShiny(pokemon) {
-    const updateObject = { shiny: true };
+  markShiny(pokemon, shiny) {
+    const updateObject = { shiny: shiny };
 
     return DB.insertIfAbsent('Pokemon', Object.assign({},
       {

--- a/app/raid.js
+++ b/app/raid.js
@@ -704,7 +704,9 @@ class Raid extends Party {
     embed.setColor('GREEN');
     embed.setTitle(`Map Link: ${gymName}`);
     embed.setURL(gymUrl);
-    embed.setDescription(raidDescription);
+
+    let shiny = this.pokemon.shiny ? Helper.getEmoji(settings.emoji.shiny) || '✨' : '';
+    embed.setDescription(raidDescription + shiny);
 
     if (pokemonUrl !== '') {
       embed.setThumbnail(pokemonUrl);

--- a/commands/admin/not-shiny.js
+++ b/commands/admin/not-shiny.js
@@ -1,25 +1,25 @@
 "use strict";
 
-const log = require('loglevel').getLogger('MarkShinyCommand'),
+const log = require('loglevel').getLogger('MarkNotShinyCommand'),
   Commando = require('discord.js-commando'),
   {CommandGroup} = require('../../app/constants'),
   Helper = require('../../app/helper'),
   Pokemon = require('../../app/pokemon'),
   settings = require('../../data/settings');
 
-class MarkShinyCommand extends Commando.Command {
+class MarkNotShinyCommand extends Commando.Command {
   constructor(client) {
     super(client, {
-      name: 'mark-shiny',
+      name: 'mark-not-shiny',
       group: CommandGroup.ADMIN,
       memberName: 'mark-shiny',
-      description: 'Marks a raid boss as potentially shiny.',
-      examples: ['\t!mark-shiny lugia'],
-      aliases: ['shiny'],
+      description: 'Marks a raid boss as not potentially shiny.',
+      examples: ['\t!mark-not-shiny lugia'],
+      aliases: ['not-shiny'],
       args: [
         {
           key: 'pokemon',
-          prompt: 'What pokémon are you marking as potentially shiny?\nExample: `lugia`\n',
+          prompt: 'What pokémon are you marking as not potentially shiny?\nExample: `lugia`\n',
           type: 'pokemon'
         }
       ],
@@ -27,7 +27,7 @@ class MarkShinyCommand extends Commando.Command {
     });
 
     client.dispatcher.addInhibitor(message => {
-      if (!!message.command && message.command.name === 'mark-shiny') {
+      if (!!message.command && message.command.name === 'mark-not-shiny') {
         if (!Helper.isBotManagement(message)) {
           return ['unauthorized', message.reply('You are not authorized to use this command.')];
         }
@@ -41,7 +41,7 @@ class MarkShinyCommand extends Commando.Command {
     const pokemon = args['pokemon'],
       tier = args['tier'];
 
-    Pokemon.markShiny(pokemon.formName, true)
+    Pokemon.markShiny(pokemon.formName, false)
       .then(result => {
         message.react(Helper.getEmoji(settings.emoji.thumbsUp) || '👍');
         Pokemon.buildIndex();
@@ -49,4 +49,4 @@ class MarkShinyCommand extends Commando.Command {
   }
 }
 
-module.exports = MarkShinyCommand;
+module.exports = MarkNotShinyCommand;

--- a/commands/admin/populate-raid-bosses.js
+++ b/commands/admin/populate-raid-bosses.js
@@ -36,10 +36,10 @@ class PopulateRaidBossesCommand extends Commando.Command {
     pokemonMetadata.forEach(pokemon => {
       if (pokemon.backupExclusive) {
         names.push(pokemon.name || 'ex');
-        promises.push(Pokemon.addRaidBoss(pokemon.name || 'ex', 'ex'));
+        promises.push(Pokemon.addRaidBoss(pokemon.name || 'ex', 'ex', pokemon.shiny));
       } else if (pokemon.backupTier) {
         names.push(pokemon.name || pokemon.backupTier + '');
-        promises.push(Pokemon.addRaidBoss(pokemon.name || pokemon.backupTier + '', pokemon.backupTier + ''));
+        promises.push(Pokemon.addRaidBoss(pokemon.name || pokemon.backupTier + '', pokemon.backupTier + '', pokemon.shiny));
       }
     });
 

--- a/commands/admin/shiny.js
+++ b/commands/admin/shiny.js
@@ -27,7 +27,7 @@ class MarkShinyCommand extends Commando.Command {
     });
 
     client.dispatcher.addInhibitor(message => {
-      if (!!message.command && message.command.name === 'raid-boss') {
+      if (!!message.command && message.command.name === 'mark-shiny') {
         if (!Helper.isBotManagement(message)) {
           return ['unauthorized', message.reply('You are not authorized to use this command.')];
         }

--- a/commands/admin/shiny.js
+++ b/commands/admin/shiny.js
@@ -13,7 +13,7 @@ class MarkShinyCommand extends Commando.Command {
       name: 'mark-shiny',
       group: CommandGroup.ADMIN,
       memberName: 'mark-shiny',
-      description: 'Adds a new raid boss.',
+      description: 'Marks a raid boss as potentially shiny.',
       examples: ['\t!mark-shiny lugia'],
       aliases: ['shiny'],
       args: [

--- a/commands/admin/shiny.js
+++ b/commands/admin/shiny.js
@@ -1,0 +1,52 @@
+"use strict";
+
+const log = require('loglevel').getLogger('MarkShinyCommand'),
+  Commando = require('discord.js-commando'),
+  {CommandGroup} = require('../../app/constants'),
+  Helper = require('../../app/helper'),
+  Pokemon = require('../../app/pokemon'),
+  settings = require('../../data/settings');
+
+class MarkShinyCommand extends Commando.Command {
+  constructor(client) {
+    super(client, {
+      name: 'mark-shiny',
+      group: CommandGroup.ADMIN,
+      memberName: 'mark-shiny',
+      description: 'Adds a new raid boss.',
+      examples: ['\t!mark-shiny lugia'],
+      aliases: ['shiny'],
+      args: [
+        {
+          key: 'pokemon',
+          prompt: 'What pokémon are you marking as potentially shiny?\nExample: `lugia`\n',
+          type: 'pokemon'
+        }
+      ],
+      guildOnly: true
+    });
+
+    client.dispatcher.addInhibitor(message => {
+      if (!!message.command && message.command.name === 'raid-boss') {
+        if (!Helper.isBotManagement(message)) {
+          return ['unauthorized', message.reply('You are not authorized to use this command.')];
+        }
+      }
+
+      return false;
+    });
+  }
+
+  async run(message, args) {
+    const pokemon = args['pokemon'],
+      tier = args['tier'];
+
+    Pokemon.markShiny(pokemon.formName)
+      .then(result => {
+        message.react(Helper.getEmoji(settings.emoji.thumbsUp) || '👍');
+        Pokemon.buildIndex();
+      }).catch(err => log.error(err));
+  }
+}
+
+module.exports = MarkShinyCommand;

--- a/data/pokemon.json
+++ b/data/pokemon.json
@@ -501,8 +501,7 @@
     "shiny": true
   },
   {
-    "name": "kingler",
-    "shiny": true
+    "name": "kingler"
   },
   {
     "name": "voltorb"

--- a/data/pokemon.json
+++ b/data/pokemon.json
@@ -170,8 +170,7 @@
   },
   {
     "name": "sandslash",
-    "tier": 2,
-    "shiny": true
+    "tier": 2
   },
   {
     "name": "sandslash_alola",
@@ -190,8 +189,7 @@
   },
   {
     "name": "nidoqueen",
-    "tier": 4,
-    "shiny": true
+    "tier": 4
   },
   {
     "name": "nidoran♂"
@@ -323,8 +321,7 @@
   },
   {
     "name": "arcanine",
-    "tier": 3,
-    "shiny": true
+    "tier": 3
   },
   {
     "name": "poliwag"
@@ -385,8 +382,7 @@
     ]
   },
   {
-    "name": "graveler",
-    "shiny": true
+    "name": "graveler"
   },
   {
     "name": "graveler_alola",
@@ -397,8 +393,7 @@
   },
   {
     "name": "golem",
-    "tier": 4,
-    "shiny": true
+    "tier": 4
   },
   {
     "name": "golem_alola",
@@ -412,8 +407,7 @@
     "shiny": true
   },
   {
-    "name": "rapidash",
-    "shiny": true
+    "name": "rapidash"
   },
   {
     "name": "slowpoke"
@@ -460,8 +454,7 @@
   },
   {
     "name": "muk",
-    "tier": 2,
-    "shiny": true
+    "tier": 2
   },
   {
     "name": "muk_alola",
@@ -477,8 +470,7 @@
   },
   {
     "name": "cloyster",
-    "tier": 2,
-    "shiny": true
+    "tier": 2
   },
   {
     "name": "gastly",
@@ -490,8 +482,7 @@
   },
   {
     "name": "gengar",
-    "tier": 3,
-    "shiny": true
+    "tier": 3
   },
   {
     "name": "onix",
@@ -503,8 +494,7 @@
     "shiny": true
   },
   {
-    "name": "hypno",
-    "shiny": true
+    "name": "hypno"
   },
   {
     "name": "krabby",
@@ -544,8 +534,7 @@
     "shiny": true
   },
   {
-    "name": "marowak",
-    "shiny": true
+    "name": "marowak"
   },
   {
     "name": "marowak_alola",
@@ -648,8 +637,7 @@
     "shiny": true
   },
   {
-    "name": "gyarados",
-    "shiny": true
+    "name": "gyarados"
   },
   {
     "name": "lapras",
@@ -664,18 +652,15 @@
   },
   {
     "name": "vaporeon",
-    "tier": 3,
-    "shiny": true
+    "tier": 3
   },
   {
     "name": "jolteon",
-    "tier": 3,
-    "shiny": true
+    "tier": 3
   },
   {
     "name": "flareon",
-    "tier": 3,
-    "shiny": true
+    "tier": 3
   },
   {
     "name": "porygon",
@@ -688,8 +673,7 @@
   },
   {
     "name": "omastar",
-    "tier": 3,
-    "shiny": true
+    "tier": 3
   },
   {
     "name": "kabuto",
@@ -698,8 +682,7 @@
   },
   {
     "name": "kabutops",
-    "tier": 3,
-    "shiny": true
+    "tier": 3
   },
   {
     "name": "aerodactyl",
@@ -740,12 +723,10 @@
     "shiny": true
   },
   {
-    "name": "dragonair",
-    "shiny": true
+    "name": "dragonair"
   },
   {
-    "name": "dragonite",
-    "shiny": true
+    "name": "dragonite"
   },
   {
     "name": "mewtwo",
@@ -761,12 +742,10 @@
   },
   {
     "name": "bayleef",
-    "tier": 1,
-    "shiny": true
+    "tier": 1
   },
   {
-    "name": "meganium",
-    "shiny": true
+    "name": "meganium"
   },
   {
     "name": "cyndaquil",
@@ -775,12 +754,10 @@
   },
   {
     "name": "quilava",
-    "tier": 1,
-    "shiny": true
+    "tier": 1
   },
   {
-    "name": "typhlosion",
-    "shiny": true
+    "name": "typhlosion"
   },
   {
     "name": "totodile",
@@ -857,12 +834,10 @@
     "shiny": true
   },
   {
-    "name": "flaaffy",
-    "shiny": true
+    "name": "flaaffy"
   },
   {
-    "name": "ampharos",
-    "shiny": true
+    "name": "ampharos"
   },
   {
     "name": "bellossom"
@@ -873,8 +848,7 @@
   },
   {
     "name": "azumarill",
-    "tier": 3,
-    "shiny": true
+    "tier": 3
   },
   {
     "name": "sudowoodo",
@@ -901,8 +875,7 @@
     "shiny": true
   },
   {
-    "name": "sunflora",
-    "shiny": true
+    "name": "sunflora"
   },
   {
     "name": "yanma",
@@ -916,13 +889,11 @@
   },
   {
     "name": "espeon",
-    "tier": 3,
-    "shiny": true
+    "tier": 3
   },
   {
     "name": "umbreon",
-    "tier": 3,
-    "shiny": true
+    "tier": 3
   },
   {
     "name": "murkrow",
@@ -940,8 +911,7 @@
     "name": "unown"
   },
   {
-    "name": "wobbuffet",
-    "shiny": true
+    "name": "wobbuffet"
   },
   {
     "name": "girafarig"
@@ -952,8 +922,7 @@
     "shiny": true
   },
   {
-    "name": "forretress",
-    "shiny": true
+    "name": "forretress"
   },
   {
     "name": "dunsparce"
@@ -970,8 +939,7 @@
   },
   {
     "name": "granbull",
-    "tier": 3,
-    "shiny": true
+    "tier": 3
   },
   {
     "name": "qwilfish"
@@ -1098,8 +1066,7 @@
     "shiny": true
   },
   {
-    "name": "pupitar",
-    "shiny": true
+    "name": "pupitar"
   },
   {
     "name": "tyranitar",
@@ -1162,8 +1129,7 @@
     "shiny": true
   },
   {
-    "name": "mightyena",
-    "shiny": true
+    "name": "mightyena"
   },
   {
     "name": "zigzagoon"
@@ -1215,8 +1181,7 @@
     "shiny": true
   },
   {
-    "name": "pelipper",
-    "shiny": true
+    "name": "pelipper"
   },
   {
     "name": "ralts"
@@ -1274,8 +1239,7 @@
     "shiny": true
   },
   {
-    "name": "hariyama",
-    "shiny": true
+    "name": "hariyama"
   },
   {
     "name": "azurill",
@@ -1306,8 +1270,7 @@
     "shiny": true
   },
   {
-    "name": "lairon",
-    "shiny": true
+    "name": "lairon"
   },
   {
     "name": "aggron",
@@ -1319,8 +1282,7 @@
     "shiny": true
   },
   {
-    "name": "medicham",
-    "shiny": true
+    "name": "medicham"
   },
   {
     "name": "electrike"
@@ -1365,8 +1327,7 @@
     "shiny": true
   },
   {
-    "name": "wailord",
-    "shiny": true
+    "name": "wailord"
   },
   {
     "name": "numel"
@@ -1407,8 +1368,7 @@
     "shiny": true
   },
   {
-    "name": "altaria",
-    "shiny": true
+    "name": "altaria"
   },
   {
     "name": "zangoose"
@@ -1475,8 +1435,7 @@
     "shiny": true
   },
   {
-    "name": "banette",
-    "shiny": true
+    "name": "banette"
   },
   {
     "name": "duskull",
@@ -1484,8 +1443,7 @@
     "shiny": true
   },
   {
-    "name": "dusclops",
-    "shiny": true
+    "name": "dusclops"
   },
   {
     "name": "tropius"
@@ -1508,8 +1466,7 @@
     "shiny": true
   },
   {
-    "name": "glalie",
-    "shiny": true
+    "name": "glalie"
   },
   {
     "name": "spheal"
@@ -1551,12 +1508,10 @@
     "shiny": true
   },
   {
-    "name": "metang",
-    "shiny": true
+    "name": "metang"
   },
   {
-    "name": "metagross",
-    "shiny": true
+    "name": "metagross"
   },
   {
     "name": "regirock",
@@ -1674,20 +1629,16 @@
     "shiny": true
   },
   {
-    "name": "luxio",
-    "shiny": true
+    "name": "luxio"
   },
   {
-    "name": "luxray",
-    "shiny": true
+    "name": "luxray"
   },
   {
-    "name": "budew",
-    "shiny": true
+    "name": "budew"
   },
   {
-    "name": "roserade",
-    "shiny": true
+    "name": "roserade"
   },
   {
     "name": "cranidos"
@@ -1747,8 +1698,7 @@
     "shiny": true
   },
   {
-    "name": "drifblim",
-    "shiny": true
+    "name": "drifblim"
   },
   {
     "name": "buneary",
@@ -1758,12 +1708,10 @@
     "name": "lopunny"
   },
   {
-    "name": "mismagius",
-    "shiny": true
+    "name": "mismagius"
   },
   {
-    "name": "honchkrow",
-    "shiny": true
+    "name": "honchkrow"
   },
   {
     "name": "glameow"
@@ -1871,27 +1819,22 @@
     "name": "tangrowth"
   },
   {
-    "name": "electivire",
-    "shiny": true
+    "name": "electivire"
   },
   {
-    "name": "magmortar",
-    "shiny": true
+    "name": "magmortar"
   },
   {
-    "name": "togekiss",
-    "shiny": true
+    "name": "togekiss"
   },
   {
     "name": "yanmega"
   },
   {
-    "name": "leafeon",
-    "shiny": true
+    "name": "leafeon"
   },
   {
-    "name": "glaceon",
-    "shiny": true
+    "name": "glaceon"
   },
   {
     "name": "gliscor"
@@ -1909,12 +1852,10 @@
     "name": "probopass"
   },
   {
-    "name": "dusknoir",
-    "shiny": true
+    "name": "dusknoir"
   },
   {
-    "name": "froslass",
-    "shiny": true
+    "name": "froslass"
   },
   {
     "name": "rotom"

--- a/data/pokemon.json
+++ b/data/pokemon.json
@@ -33,49 +33,61 @@
   },
   {
     "name": "bulbasaur",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
     "name": "ivysaur",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
     "name": "venusaur",
-    "tier": 4
+    "tier": 4,
+    "shiny": true
   },
   {
     "name": "charmander",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
     "name": "charmeleon",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
     "name": "charizard",
-    "tier": 4
+    "tier": 4,
+    "shiny": true
   },
   {
     "name": "squirtle",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
     "name": "wartortle",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
     "name": "blastoise",
-    "tier": 4
+    "tier": 4,
+    "shiny": true
   },
   {
-    "name": "caterpie"
+    "name": "caterpie",
+    "shiny": true
   },
   {
     "name": "metapod",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
-    "name": "butterfree"
+    "name": "butterfree",
+    "shiny": true
   },
   {
     "name": "weedle"
@@ -128,10 +140,12 @@
     "name": "arbok"
   },
   {
-    "name": "pikachu"
+    "name": "pikachu",
+    "shiny": true
   },
   {
-    "name": "raichu"
+    "name": "raichu",
+    "shiny": true
   },
   {
     "name": "raichu_alola",
@@ -140,10 +154,12 @@
       "alo",
       "alochu"
     ],
-    "tier": 3
+    "tier": 3,
+    "shiny": true
   },
   {
-    "name": "sandshrew"
+    "name": "sandshrew",
+    "shiny": true
   },
   {
     "name": "sandshrew_alola",
@@ -154,7 +170,8 @@
   },
   {
     "name": "sandslash",
-    "tier": 2
+    "tier": 2,
+    "shiny": true
   },
   {
     "name": "sandslash_alola",
@@ -164,14 +181,17 @@
     ]
   },
   {
-    "name": "nidoran♀"
+    "name": "nidoran♀",
+    "shiny": true
   },
   {
-    "name": "nidorina"
+    "name": "nidorina",
+    "shiny": true
   },
   {
     "name": "nidoqueen",
-    "tier": 4
+    "tier": 4,
+    "shiny": true
   },
   {
     "name": "nidoran♂"
@@ -298,11 +318,13 @@
     "tier": 2
   },
   {
-    "name": "growlithe"
+    "name": "growlithe",
+    "shiny": true
   },
   {
     "name": "arcanine",
-    "tier": 3
+    "tier": 3,
+    "shiny": true
   },
   {
     "name": "poliwag"
@@ -352,7 +374,8 @@
     "tier": 2
   },
   {
-    "name": "geodude"
+    "name": "geodude",
+    "shiny": true
   },
   {
     "name": "geodude_alola",
@@ -362,7 +385,8 @@
     ]
   },
   {
-    "name": "graveler"
+    "name": "graveler",
+    "shiny": true
   },
   {
     "name": "graveler_alola",
@@ -373,7 +397,8 @@
   },
   {
     "name": "golem",
-    "tier": 4
+    "tier": 4,
+    "shiny": true
   },
   {
     "name": "golem_alola",
@@ -383,10 +408,12 @@
     ]
   },
   {
-    "name": "ponyta"
+    "name": "ponyta",
+    "shiny": true
   },
   {
-    "name": "rapidash"
+    "name": "rapidash",
+    "shiny": true
   },
   {
     "name": "slowpoke"
@@ -397,11 +424,13 @@
   },
   {
     "name": "magnemite",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
     "name": "magneton",
-    "tier": 2
+    "tier": 2,
+    "shiny": true
   },
   {
     "name": "farfetch'd"
@@ -420,7 +449,8 @@
     "tier": 2
   },
   {
-    "name": "grimer"
+    "name": "grimer",
+    "shiny": true
   },
   {
     "name": "grimer_alola",
@@ -431,7 +461,8 @@
   },
   {
     "name": "muk",
-    "tier": 2
+    "tier": 2,
+    "shiny": true
   },
   {
     "name": "muk_alola",
@@ -442,21 +473,26 @@
   },
   {
     "name": "shellder",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
     "name": "cloyster",
-    "tier": 2
+    "tier": 2,
+    "shiny": true
   },
   {
-    "name": "gastly"
+    "name": "gastly",
+    "shiny": true
   },
   {
-    "name": "haunter"
+    "name": "haunter",
+    "shiny": true
   },
   {
     "name": "gengar",
-    "tier": 3
+    "tier": 3,
+    "shiny": true
   },
   {
     "name": "onix",
@@ -464,16 +500,20 @@
   },
   {
     "name": "drowzee",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
-    "name": "hypno"
+    "name": "hypno",
+    "shiny": true
   },
   {
-    "name": "krabby"
+    "name": "krabby",
+    "shiny": true
   },
   {
-    "name": "kingler"
+    "name": "kingler",
+    "shiny": true
   },
   {
     "name": "voltorb"
@@ -501,10 +541,12 @@
     "tier": 2
   },
   {
-    "name": "cubone"
+    "name": "cubone",
+    "shiny": true
   },
   {
-    "name": "marowak"
+    "name": "marowak",
+    "shiny": true
   },
   {
     "name": "marowak_alola",
@@ -513,7 +555,8 @@
       "alo",
       "alowak"
     ],
-    "tier": 4
+    "tier": 4,
+    "shiny": true
   },
   {
     "name": "hitmonlee",
@@ -583,15 +626,18 @@
   },
   {
     "name": "electabuzz",
-    "tier": 2
+    "tier": 2,
+    "shiny": true
   },
   {
     "name": "magmar",
-    "tier": 2
+    "tier": 2,
+    "shiny": true
   },
   {
     "name": "pinsir",
-    "tier": 3
+    "tier": 3,
+    "shiny": true
   },
   {
     "name": "tauros"
@@ -601,10 +647,12 @@
     "nickname": [
       "karp"
     ],
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
-    "name": "gyarados"
+    "name": "gyarados",
+    "shiny": true
   },
   {
     "name": "lapras",
@@ -614,19 +662,23 @@
     "name": "ditto"
   },
   {
-    "name": "eevee"
+    "name": "eevee",
+    "shiny": true
   },
   {
     "name": "vaporeon",
-    "tier": 3
+    "tier": 3,
+    "shiny": true
   },
   {
     "name": "jolteon",
-    "tier": 3
+    "tier": 3,
+    "shiny": true
   },
   {
     "name": "flareon",
-    "tier": 3
+    "tier": 3,
+    "shiny": true
   },
   {
     "name": "porygon",
@@ -634,23 +686,28 @@
   },
   {
     "name": "omanyte",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
     "name": "omastar",
-    "tier": 3
+    "tier": 3,
+    "shiny": true
   },
   {
     "name": "kabuto",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
     "name": "kabutops",
-    "tier": 3
+    "tier": 3,
+    "shiny": true
   },
   {
     "name": "aerodactyl",
-    "tier": 3
+    "tier": 3,
+    "shiny": true
   },
   {
     "name": "snorlax",
@@ -661,31 +718,37 @@
     "nickname": [
       "arty"
     ],
-    "tier": 5
+    "tier": 5,
+    "shiny": true
   },
   {
     "name": "zapdos",
     "nickname": [
       "zappy"
     ],
-    "tier": 5
+    "tier": 5,
+    "shiny": true
   },
   {
     "name": "moltres",
     "nickname": [
       "molty"
     ],
-    "tier": 5
+    "tier": 5,
+    "shiny": true
   },
   {
     "name": "dratini",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
-    "name": "dragonair"
+    "name": "dragonair",
+    "shiny": true
   },
   {
-    "name": "dragonite"
+    "name": "dragonite",
+    "shiny": true
   },
   {
     "name": "mewtwo",
@@ -696,25 +759,31 @@
   },
   {
     "name": "chikorita",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
     "name": "bayleef",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
-    "name": "meganium"
+    "name": "meganium",
+    "shiny": true
   },
   {
     "name": "cyndaquil",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
     "name": "quilava",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
-    "name": "typhlosion"
+    "name": "typhlosion",
+    "shiny": true
   },
   {
     "name": "totodile",
@@ -772,11 +841,13 @@
     "name": "igglybuff"
   },
   {
-    "name": "togepi"
+    "name": "togepi",
+    "shiny": true
   },
   {
     "name": "togetic",
-    "tier": 4
+    "tier": 4,
+    "shiny": true
   },
   {
     "name": "natu"
@@ -786,23 +857,28 @@
   },
   {
     "name": "mareep",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
-    "name": "flaaffy"
+    "name": "flaaffy",
+    "shiny": true
   },
   {
-    "name": "ampharos"
+    "name": "ampharos",
+    "shiny": true
   },
   {
     "name": "bellossom"
   },
   {
-    "name": "marill"
+    "name": "marill",
+    "shiny": true
   },
   {
     "name": "azumarill",
-    "tier": 3
+    "tier": 3,
+    "shiny": true
   },
   {
     "name": "sudowoodo",
@@ -825,10 +901,12 @@
   },
   {
     "name": "sunkern",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
-    "name": "sunflora"
+    "name": "sunflora",
+    "shiny": true
   },
   {
     "name": "yanma",
@@ -842,37 +920,44 @@
   },
   {
     "name": "espeon",
-    "tier": 3
+    "tier": 3,
+    "shiny": true
   },
   {
     "name": "umbreon",
-    "tier": 3
+    "tier": 3,
+    "shiny": true
   },
   {
-    "name": "murkrow"
+    "name": "murkrow",
+    "shiny": true
   },
   {
     "name": "slowking"
   },
   {
     "name": "misdreavus",
-    "tier": 2
+    "tier": 2,
+    "shiny": true
   },
   {
     "name": "unown"
   },
   {
-    "name": "wobbuffet"
+    "name": "wobbuffet",
+    "shiny": true
   },
   {
     "name": "girafarig"
   },
   {
     "name": "pineco",
-    "tier": 2
+    "tier": 2,
+    "shiny": true
   },
   {
-    "name": "forretress"
+    "name": "forretress",
+    "shiny": true
   },
   {
     "name": "dunsparce"
@@ -884,11 +969,13 @@
     "name": "steelix"
   },
   {
-    "name": "snubbull"
+    "name": "snubbull",
+    "shiny": true
   },
   {
     "name": "granbull",
-    "tier": 3
+    "tier": 3,
+    "shiny": true
   },
   {
     "name": "qwilfish"
@@ -938,7 +1025,8 @@
     "name": "octillery"
   },
   {
-    "name": "delibird"
+    "name": "delibird",
+    "shiny": true
   },
   {
     "name": "mantine"
@@ -948,11 +1036,13 @@
     "tier": 3
   },
   {
-    "name": "houndour"
+    "name": "houndour",
+    "shiny": true
   },
   {
     "name": "houndoom",
-    "tier": 4
+    "tier": 4,
+    "shiny": true
   },
   {
     "name": "kingdra"
@@ -983,10 +1073,12 @@
     "name": "smoochum"
   },
   {
-    "name": "elekid"
+    "name": "elekid",
+    "shiny": true
   },
   {
-    "name": "magby"
+    "name": "magby",
+    "shiny": true
   },
   {
     "name": "miltank"
@@ -1007,21 +1099,25 @@
     "tier": 5
   },
   {
-    "name": "larvitar"
+    "name": "larvitar",
+    "shiny": true
   },
   {
-    "name": "pupitar"
+    "name": "pupitar",
+    "shiny": true
   },
   {
     "name": "tyranitar",
     "nickname": [
       "ttar"
     ],
-    "tier": 4
+    "tier": 4,
+    "shiny": true
   },
   {
     "name": "lugia",
-    "tier": 5
+    "tier": 5,
+    "shiny": true
   },
   {
     "name": "ho_oh",
@@ -1032,7 +1128,8 @@
       "hoho",
       "santa"
     ],
-    "tier": 5
+    "tier": 5,
+    "shiny": true
   },
   {
     "name": "celebi"
@@ -1067,10 +1164,12 @@
     "name": "swampert"
   },
   {
-    "name": "poochyena"
+    "name": "poochyena",
+    "shiny": true
   },
   {
-    "name": "mightyena"
+    "name": "mightyena",
+    "shiny": true
   },
   {
     "name": "zigzagoon"
@@ -1118,10 +1217,12 @@
     "name": "swellow"
   },
   {
-    "name": "wingull"
+    "name": "wingull",
+    "shiny": true
   },
   {
-    "name": "pelipper"
+    "name": "pelipper",
+    "shiny": true
   },
   {
     "name": "ralts"
@@ -1175,13 +1276,16 @@
   },
   {
     "name": "makuhita",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
-    "name": "hariyama"
+    "name": "hariyama",
+    "shiny": true
   },
   {
-    "name": "azurill"
+    "name": "azurill",
+    "shiny": true
   },
   {
     "name": "nosepass",
@@ -1195,28 +1299,35 @@
   },
   {
     "name": "sableye",
-    "tier": 2
+    "tier": 2,
+    "shiny": true
   },
   {
     "name": "mawile",
-    "tier": 2
+    "tier": 2,
+    "shiny": true
   },
   {
-    "name": "aron"
+    "name": "aron",
+    "shiny": true
   },
   {
-    "name": "lairon"
+    "name": "lairon",
+    "shiny": true
   },
   {
     "name": "aggron",
-    "tier": 4
+    "tier": 4,
+    "shiny": true
   },
   {
     "name": "meditite",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
-    "name": "medicham"
+    "name": "medicham",
+    "shiny": true
   },
   {
     "name": "electrike"
@@ -1239,7 +1350,8 @@
   },
   {
     "name": "roselia",
-    "tier": 2
+    "tier": 2,
+    "shiny": true
   },
   {
     "name": "gulpin"
@@ -1256,10 +1368,12 @@
   },
   {
     "name": "wailmer",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
-    "name": "wailord"
+    "name": "wailord",
+    "shiny": true
   },
   {
     "name": "numel"
@@ -1296,10 +1410,12 @@
   },
   {
     "name": "swablu",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
-    "name": "altaria"
+    "name": "altaria",
+    "shiny": true
   },
   {
     "name": "zangoose"
@@ -1362,17 +1478,21 @@
   },
   {
     "name": "shuppet",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
-    "name": "banette"
+    "name": "banette",
+    "shiny": true
   },
   {
     "name": "duskull",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
-    "name": "dusclops"
+    "name": "dusclops",
+    "shiny": true
   },
   {
     "name": "tropius"
@@ -1382,17 +1502,21 @@
   },
   {
     "name": "absol",
-    "tier": 4
+    "tier": 4,
+    "shiny": true
   },
   {
-    "name": "wynaut"
+    "name": "wynaut",
+    "shiny": true
   },
   {
     "name": "snorunt",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
-    "name": "glalie"
+    "name": "glalie",
+    "shiny": true
   },
   {
     "name": "spheal"
@@ -1417,7 +1541,8 @@
     "name": "relicanth"
   },
   {
-    "name": "luvdisc"
+    "name": "luvdisc",
+    "shiny": true
   },
   {
     "name": "bagon"
@@ -1429,13 +1554,16 @@
     "name": "salamence"
   },
   {
-    "name": "beldum"
+    "name": "beldum",
+    "shiny": true
   },
   {
-    "name": "metang"
+    "name": "metang",
+    "shiny": true
   },
   {
-    "name": "metagross"
+    "name": "metagross",
+    "shiny": true
   },
   {
     "name": "regirock",
@@ -1459,7 +1587,8 @@
   },
   {
     "name": "kyogre",
-    "tier": 5
+    "tier": 5,
+    "shiny": true
   },
   {
     "name": "groudon",
@@ -1548,19 +1677,24 @@
   },
   {
     "name": "shinx",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
-    "name": "luxio"
+    "name": "luxio",
+    "shiny": true
   },
   {
-    "name": "luxray"
+    "name": "luxray",
+    "shiny": true
   },
   {
-    "name": "budew"
+    "name": "budew",
+    "shiny": true
   },
   {
-    "name": "roserade"
+    "name": "roserade",
+    "shiny": true
   },
   {
     "name": "cranidos"
@@ -1616,10 +1750,12 @@
   },
   {
     "name": "drifloon",
-    "tier": 1
+    "tier": 1,
+    "shiny": true
   },
   {
-    "name": "drifblim"
+    "name": "drifblim",
+    "shiny": true
   },
   {
     "name": "buneary",
@@ -1629,10 +1765,12 @@
     "name": "lopunny"
   },
   {
-    "name": "mismagius"
+    "name": "mismagius",
+    "shiny": true
   },
   {
-    "name": "honchkrow"
+    "name": "honchkrow",
+    "shiny": true
   },
   {
     "name": "glameow"
@@ -1728,7 +1866,8 @@
     "name": "weavile"
   },
   {
-    "name": "magnezone"
+    "name": "magnezone",
+    "shiny": true
   },
   {
     "name": "lickilicky"
@@ -1740,22 +1879,27 @@
     "name": "tangrowth"
   },
   {
-    "name": "electivire"
+    "name": "electivire",
+    "shiny": true
   },
   {
-    "name": "magmortar"
+    "name": "magmortar",
+    "shiny": true
   },
   {
-    "name": "togekiss"
+    "name": "togekiss",
+    "shiny": true
   },
   {
     "name": "yanmega"
   },
   {
-    "name": "leafeon"
+    "name": "leafeon",
+    "shiny": true
   },
   {
-    "name": "glaceon"
+    "name": "glaceon",
+    "shiny": true
   },
   {
     "name": "gliscor"
@@ -1773,10 +1917,12 @@
     "name": "probopass"
   },
   {
-    "name": "dusknoir"
+    "name": "dusknoir",
+    "shiny": true
   },
   {
-    "name": "froslass"
+    "name": "froslass",
+    "shiny": true
   },
   {
     "name": "rotom"

--- a/data/pokemon.json
+++ b/data/pokemon.json
@@ -429,8 +429,7 @@
   },
   {
     "name": "magneton",
-    "tier": 2,
-    "shiny": true
+    "tier": 2
   },
   {
     "name": "farfetch'd"
@@ -846,8 +845,7 @@
   },
   {
     "name": "togetic",
-    "tier": 4,
-    "shiny": true
+    "tier": 4
   },
   {
     "name": "natu"
@@ -1041,8 +1039,7 @@
   },
   {
     "name": "houndoom",
-    "tier": 4,
-    "shiny": true
+    "tier": 4
   },
   {
     "name": "kingdra"
@@ -1111,8 +1108,7 @@
     "nickname": [
       "ttar"
     ],
-    "tier": 4,
-    "shiny": true
+    "tier": 4
   },
   {
     "name": "lugia",
@@ -1318,7 +1314,6 @@
   {
     "name": "aggron",
     "tier": 4,
-    "shiny": true
   },
   {
     "name": "meditite",
@@ -1866,8 +1861,7 @@
     "name": "weavile"
   },
   {
-    "name": "magnezone",
-    "shiny": true
+    "name": "magnezone"
   },
   {
     "name": "lickilicky"

--- a/data/pokemon.json
+++ b/data/pokemon.json
@@ -625,13 +625,11 @@
   },
   {
     "name": "electabuzz",
-    "tier": 2,
-    "shiny": true
+    "tier": 2
   },
   {
     "name": "magmar",
-    "tier": 2,
-    "shiny": true
+    "tier": 2
   },
   {
     "name": "pinsir",

--- a/data/settings.json
+++ b/data/settings.json
@@ -15,7 +15,8 @@
   "databaseRaids": true,
   "emoji": {
     "thumbsUp": "pinethumbsup",
-    "thumbsDown": "pinethumbsdown"
+    "thumbsDown": "pinethumbsdown",
+    "shiny": "pineshiny"
   },
   "features": {
     "exGymChannel": true,

--- a/index.js
+++ b/index.js
@@ -130,7 +130,8 @@ Client.registry.registerCommands([
   require('./commands/admin/populate-raid-bosses'),
   require('./commands/util/boss-tier'),
   require('./commands/admin/autoset'),
-  require('./commands/admin/shiny')
+  require('./commands/admin/shiny'),
+  require('./commands/admin/not-shiny')
 ]);
 
 if (privateSettings.regionMapLink !== '') {

--- a/index.js
+++ b/index.js
@@ -129,7 +129,8 @@ Client.registry.registerCommands([
   require('./commands/admin/raid-boss'),
   require('./commands/admin/populate-raid-bosses'),
   require('./commands/util/boss-tier'),
-  require('./commands/admin/autoset')
+  require('./commands/admin/autoset'),
+  require('./commands/admin/shiny')
 ]);
 
 if (privateSettings.regionMapLink !== '') {


### PR DESCRIPTION
This PR does the following:

- Adds a shiny indicator to raid boss information in raid channels
- Adds a shiny attribute to `pokemon.json` and `Pokemon` DB table
- Updates `addRaidBoss` to take optional shiny attribute
- Adds new `markShiny` function
- Adds new `!mark-shiny` admin-only command
- Updates `!populate-raid-bosses` to use the `pokemon.json` shiny attribute.