### PR TITLE
Fix date entry to allow time/date or date/time ordering

### DIFF
--- a/data/private-settings.json.default
+++ b/data/private-settings.json.default
@@ -4,7 +4,7 @@
   "owner": "",
   "pokemonUrlBase": "",
   "githubRepo": "",
-  "hithubUser": "",
+  "githubUser": "",
   "githubPassword": "",
   "googleApiKey": "",
   "regionMapLink": "",

--- a/data/settings.json
+++ b/data/settings.json
@@ -3,6 +3,8 @@
   "standardRaidHatchedDuration": 45,
   "exclusiveRaidIncubateDuration": 20160,
   "exclusiveRaidHatchedDuration": 45,
+  "earliestRaidEggTime": 300,
+  "latestRaidEggTime": 1170,
   "startClearTime": 10,
   "deletionGraceTime": 5,
   "deletionWarningTime": 10,

--- a/types/time.js
+++ b/types/time.js
@@ -144,6 +144,17 @@ class TimeType extends Commando.ArgumentType {
 
       if (enteredDate.isValid()) {
         possibleTimes.push(...TimeType.generateTimes(enteredDate, arg.key, raidHatchTime));
+
+        // Make sure a non-military, non-meridian time doesn't set a time in
+        // the wee hours of the night.
+        const startOfDay = enteredDate.clone().startOf('day'),
+          earliestTime = startOfDay.clone().add(settings.earliestRaidEggTime, 'minutes'),
+          latestTime = startOfDay.clone().add(settings.latestRaidEggTime, 'minutes');
+        if (enteredDate.isBefore(earliestTime)) {
+          enteredDate.add(12, 'hours');
+        } else if (enteredDate.isAfter(latestTime)) {
+          enteredDate.add(-12, 'hours');
+        }
       }
     }
 

--- a/types/time.js
+++ b/types/time.js
@@ -104,7 +104,7 @@ class TimeType extends Commando.ArgumentType {
       // mark this is a valid time.
       return true;
     } else {
-      const absoluteMatch = valueToParse.match(/^at(.*)|(.*[ap]m?(?: +\d+\/\d+)?)$/i);
+      const absoluteMatch = valueToParse.match(/^at(.*)|(.*(?:[ap]m?|\d\/\d|\d{3}).*)/i);
 
       if (absoluteMatch) {
         valueToParse = (absoluteMatch[1] || absoluteMatch[2]).trim();

--- a/types/time.js
+++ b/types/time.js
@@ -14,7 +14,7 @@ class TimeType extends Commando.ArgumentType {
     super(client, 'time');
   }
 
-  validate(value, message, arg) {
+  getPossibleTimes(value, message, arg) {
     const isExRaid = this.isExclusiveRaid(value, message, arg),
       partyExists = PartyManager.validParty(message.channel.id),
       now = moment(),
@@ -151,6 +151,19 @@ class TimeType extends Commando.ArgumentType {
       return `"${value}" is not a valid duration or time!\n\n${arg.prompt}`;
     }
 
+    possibleTimes.unshift(firstPossibleTime);
+    possibleTimes.push(lastPossibleTime);
+
+    return possibleTimes;
+  }
+
+  validate(value, message, arg) {
+    const possibleTimes = this.getPossibleTimes(value, message, arg);
+
+    if (!(possibleTimes instanceof Array))
+      return possibleTimes; // error or other unusable value
+    const firstPossibleTime = possibleTimes.shift(),
+      lastPossibleTime = possibleTimes.pop();
     if (possibleTimes.find(possibleTime =>
       this.isValidTime(possibleTime, firstPossibleTime, lastPossibleTime))) {
       return true;
@@ -167,137 +180,12 @@ class TimeType extends Commando.ArgumentType {
   }
 
   parse(value, message, arg) {
-    const isExRaid = this.isExclusiveRaid(value, message, arg),
-      partyExists = PartyManager.validParty(message.channel.id),
-      now = moment(),
-      partyCreationTime = partyExists ?
-        moment(PartyManager.getParty(message.channel.id).creationTime) :
-        now,
-      raidHatchTime = partyExists && !!PartyManager.getParty(message.channel.id).hatchTime ?
-        moment(PartyManager.getParty(message.channel.id).hatchTime) :
-        undefined,
-      pokemon = partyExists ?
-        PartyManager.getParty(message.channel.id).pokemon :
-        message.pokemon,
-      incubationDuration = pokemon && !!pokemon.incubation ?
-        pokemon.incubation :
-        isExRaid ?
-          settings.exclusiveRaidIncubateDuration :
-          settings.standardRaidIncubateDuration,
-      hatchedDuration = pokemon && !!pokemon.duration ?
-        pokemon.duration :
-        isExRaid ?
-          settings.exclusiveRaidHatchedDuration :
-          settings.standardRaidHatchedDuration;
+    const possibleTimes = this.getPossibleTimes(value, message, arg);
 
-    let firstPossibleTime,
-      maxDuration,
-      lastPossibleTime;
-
-    // Figure out valid first and last possible times for this time
-    switch (arg.key) {
-      case TimeParameter.START:
-        // Start time - valid range is now (or hatch time if it exists, whichever is later)
-        // through raid's end time
-        const party = PartyManager.getParty(message.channel.id),
-          hatchTime = party ?
-            party.hatchTime :
-            undefined,
-          endTime = party ?
-            party.endTime :
-            undefined;
-
-        if (hatchTime) {
-          const hatchTimeMoment = moment(hatchTime);
-
-          firstPossibleTime = now.isAfter(hatchTimeMoment) ?
-            now :
-            hatchTimeMoment;
-        } else {
-          firstPossibleTime = now;
-        }
-
-        const partyEndTime = endTime !== TimeType.UNDEFINED_END_TIME ?
-          moment(endTime) :
-          partyCreationTime.clone().add(incubationDuration + hatchedDuration, 'minutes');
-
-        maxDuration = incubationDuration + hatchedDuration;
-        lastPossibleTime = partyEndTime;
-        break;
-
-      case TimeParameter.HATCH: {
-        // Hatch time - valid range is up to hatched duration in the past
-        // through incubation period past raid creation time
-        firstPossibleTime = now.clone().add(-hatchedDuration, 'minutes');
-        maxDuration = incubationDuration;
-        lastPossibleTime = partyCreationTime.clone().add(maxDuration, 'minutes');
-        break;
-      }
-
-      case TimeParameter.END:
-        // End time - valid range is now through incubation plus hatch duration past creation time
-        firstPossibleTime = now;
-        maxDuration = incubationDuration + hatchedDuration;
-        lastPossibleTime = partyCreationTime.clone().add(maxDuration, 'minutes');
-        break;
-    }
-
-    let valueToParse = value.trim(),
-      possibleTimes = [],
-      timeMode = TimeMode.AUTODETECT;
-
-    if (valueToParse.match(/^in/i)) {
-      valueToParse = valueToParse.substring(2).trim();
-      timeMode = TimeMode.RELATIVE;
-    } else if (raidHatchTime && ['hatch', 'start'].indexOf(valueToParse.toLowerCase()) !== -1) {
-      valueToParse = raidHatchTime.format('h:m a');
-      timeMode = TimeMode.ABSOLUTE;
-    }  else if (['unset', 'cancel', 'none'].indexOf(valueToParse.toLowerCase()) !== -1) {
-      // return a value to indicate unset & meet.
-      return -1;
-    } else {
-      const absoluteMatch = valueToParse.match(/^at(.*)|(.*[ap]m?)$/i);
-
-      if (absoluteMatch) {
-        valueToParse = (absoluteMatch[1] || absoluteMatch[2]).trim();
-        timeMode = TimeMode.ABSOLUTE;
-      }
-    }
-
-    if (timeMode !== TimeMode.ABSOLUTE) {
-      let duration;
-
-      if (valueToParse.indexOf(':') === -1) {
-        duration = moment.duration(Number.parseInt(valueToParse), 'minutes');
-      } else {
-        const anyDuration = valueToParse.split(':')
-          .map(part => Number.parseInt(part))
-          .find(number => number !== 0) !== undefined;
-
-        if (anyDuration) {
-          duration = moment.duration(valueToParse);
-
-          if (duration.isValid() && duration.asMilliseconds() === 0) {
-            // set to invalid duration
-            duration = moment.duration.invalid();
-          }
-        } else {
-          duration = moment.duration(0);
-        }
-      }
-
-      if (moment.isDuration(duration) && duration.isValid() && duration.asMinutes() < maxDuration) {
-        possibleTimes.push(now.clone().add(duration));
-      }
-    }
-
-    if (timeMode !== TimeMode.RELATIVE) {
-      const enteredDate = moment(valueToParse, ['hmm a', 'Hmm', 'h:m a', 'H:m', 'M-D hmm a', 'M-D Hmm', 'M-D h:m a', 'M-D H:m', 'M-D h a', 'M-D H']);
-
-      if (enteredDate.isValid()) {
-        possibleTimes.push(...TimeType.generateTimes(enteredDate, arg.key, raidHatchTime));
-      }
-    }
+    if (!(possibleTimes instanceof Array))
+      return -1; // cancel
+    const firstPossibleTime = possibleTimes.shift(),
+      lastPossibleTime = possibleTimes.pop();
 
     return possibleTimes.find(possibleTime =>
       this.isValidTime(possibleTime, firstPossibleTime, lastPossibleTime)).valueOf();

--- a/types/time.js
+++ b/types/time.js
@@ -104,7 +104,7 @@ class TimeType extends Commando.ArgumentType {
       // mark this is a valid time.
       return true;
     } else {
-      const absoluteMatch = valueToParse.match(/^at(.*)|(.*[ap]m?)$/i);
+      const absoluteMatch = valueToParse.match(/^at(.*)|(.*[ap]m?(?: +\d+\/\d+)?)$/i);
 
       if (absoluteMatch) {
         valueToParse = (absoluteMatch[1] || absoluteMatch[2]).trim();
@@ -140,7 +140,7 @@ class TimeType extends Commando.ArgumentType {
     }
 
     if (timeMode !== TimeMode.RELATIVE) {
-      const enteredDate = moment(valueToParse, ['hmm a', 'Hmm', 'h:m a', 'H:m', 'M-D hmm a', 'M-D Hmm', 'M-D h:m a', 'M-D H:m', 'M-D h a', 'M-D H']);
+      const enteredDate = moment(valueToParse, ['hmm a', 'Hmm', 'h:m a', 'H:m', 'M-D hmm a', 'M-D Hmm', 'M-D h:m a', 'M-D H:m', 'M-D h a', 'M-D H', 'hmm a M-D', 'Hmm M-D', 'h:m a M-D', 'H:m M-D', 'h a M-D', 'H M-D']);
 
       if (enteredDate.isValid()) {
         possibleTimes.push(...TimeType.generateTimes(enteredDate, arg.key, raidHatchTime));


### PR DESCRIPTION
-  Allow time or date to be entered first for time commands
- Always assume three-digit entries to be an absolute time
- Limit absolute times to reasonable hours so that EX raids are no longer accidentally posted to 1am